### PR TITLE
feat(ledger): config-in-ledger (scheme v2) + AUDIT.md accuracy pass

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -3,8 +3,10 @@
 **Audience:** any human or AI agent auditing the tenby10 desktop client before trusting it with
 OS-level input and screen access.
 
-**Claim under audit:** *"tenby10 is not a keylogger, does not capture anything sensitive, keeps
-everything local, and scores your focus by fair, inspectable rules."*
+**Claim under audit:** *"tenby10 is not a keylogger, does not capture anything sensitive, keeps your
+raw activity on your machine, and scores your focus by fair, inspectable rules."* When you enroll and
+share a link, signed 10-minute *summaries* and your scoring configuration are uploaded — never raw
+keystrokes, screenshots, or window titles (§2).
 
 This guide maps each of those claims to the exact source that proves (or, honestly, does **not** yet
 prove) it. Every reference is `file:line` and is meant to be opened and read directly — do not take
@@ -21,20 +23,21 @@ auditable; the cloud portal is not part of this repository.
 
 | # | Claim | Status | Primary evidence |
 |---|-------|--------|------------------|
-| 1 | No key **content** is captured (not a keylogger) | ✅ Verified in code | [daemon.rs:88](daemon/src/daemon.rs#L88) — `KeyPress(_)` discards the key value |
-| 2 | Only counts/metadata are stored per minute | ✅ Verified | [daemon.rs:235](daemon/src/daemon.rs#L235), [db.rs schema](daemon/src/db.rs) |
-| 3 | Raw screenshots never touch disk; only blurred JPEGs saved | ✅ Verified | [screen.rs:47-66](daemon/src/screen.rs#L47) |
-| 4 | Nothing is sent to a tenby10 cloud server | ✅ Verified (no such code exists yet) | No sync/HTTP-egress module in `daemon/src` |
-| 5 | The only outbound network is your **own** BYOK LLM, opt-in | ✅ Verified | [llm.rs](daemon/src/llm.rs), gated by [daemon.rs:432](daemon/src/daemon.rs#L432) |
+| 1 | No key **content** is captured (not a keylogger) | ✅ Verified in code | [daemon.rs:145](daemon/src/daemon.rs#L145) — `KeyPress(_)` discards the key value |
+| 2 | Only counts/metadata are stored per minute | ✅ Verified | [daemon.rs:334](daemon/src/daemon.rs#L334), [db.rs schema](daemon/src/db.rs) |
+| 3 | Raw screenshots never touch disk; only blurred JPEGs saved | ✅ Verified | [screen.rs:27-54](daemon/src/screen.rs#L27) |
+| 4 | Raw keystrokes, screenshots & window titles never leave the machine | ✅ Verified | Only signed slot *summaries* + your scoring config upload, and only once enrolled — [sync.rs](daemon/src/sync.rs) |
+| 5 | Cloud sync (when enrolled) is category/count summaries + hashes + config; your BYOK LLM is the only other egress | ✅ Verified | [sync.rs](daemon/src/sync.rs); LLM in [llm.rs](daemon/src/llm.rs), gated by [daemon.rs:570](daemon/src/daemon.rs#L570) |
 | 6 | Screenshots are never uploaded anywhere | ✅ Verified (stronger than claimed) | No image is attached to any LLM call — see Gap G1 |
 | 7 | Focus-scoring rules are deterministic and inspectable | ✅ Verified | [evaluator.rs](daemon/src/evaluator.rs), [entropy.rs](daemon/src/entropy.rs) |
 | 8 | Local logs are tamper-evident (full-payload hash chain) + self-signed when enrolled | ✅ Verified | [db.rs `insert_slot_summary`/`verify_ledger_integrity`](daemon/src/db.rs) |
 | — | Secrets stored in OS keychain | ✅ Verified | [config.rs `save_config`/`load_config`](daemon/src/config.rs) — `private_key` & `llm_api_key` kept in the OS keychain via the `keyring` crate |
 | — | Local dashboard makes no third-party calls | ✅ Verified | [dashboard.rs](daemon/src/dashboard.rs) — Outfit font embedded as a data URI; no CDN `<link>` |
 
-Bottom line: the core privacy claims — **no keylogging, no cloud exfiltration, local-only raw
-data** — hold up against the code. One honest gap remains between marketing copy and code (G1 below);
-it does not leak your keystrokes or raw screen, but it should be closed so the code matches what we say.
+Bottom line: the core privacy claims — **no keylogging, and your raw keystrokes, screenshots, and
+window titles never leave the machine** — hold up against the code. When you enroll and sync, signed
+10-minute *summaries* and your scoring configuration are uploaded to the cloud (§2); raw activity is
+not. One honest gap between marketing copy and code remains (G1 below).
 
 ---
 
@@ -44,22 +47,22 @@ it does not leak your keystrokes or raw screen, but it should be closed so the c
 `KeyPress(_)` — the underscore **discards** the actual key/character. All it does is `+1` a counter
 and record the *timing gap* between presses (for bot detection), never *what* was typed.
 
-- [daemon.rs:87-98](daemon/src/daemon.rs#L87) — `KeyPress(_)` → increment `keystroke_count`, push
+- [daemon.rs:145-155](daemon/src/daemon.rs#L145) — `KeyPress(_)` → increment `keystroke_count`, push
   the inter-key interval in ms. The keycode is pattern-matched away.
-- [daemon.rs:99-103](daemon/src/daemon.rs#L99) — mouse buttons and scroll are counted the same way
+- [daemon.rs:156-161](daemon/src/daemon.rs#L156) — mouse buttons and scroll are counted the same way
   (counts only).
-- [daemon.rs:105-118](daemon/src/daemon.rs#L105) — mouse *movement* stores `(x, y, timestamp)` for
+- [daemon.rs:162-175](daemon/src/daemon.rs#L162) — mouse *movement* stores `(x, y, timestamp)` for
   entropy analysis. This is cursor coordinates, not content.
-- A **second, listen-only** macOS tap in [provenance.rs](daemon/src/provenance.rs) (issue #87) reads
-  only the `kCGEventSourceStateID` field — whether an event came from real hardware vs. software
-  injection — and counts synthetic vs. genuine events. It never reads the key value either, and passes
-  every event through unchanged.
+- A **second, listen-only** tap in [provenance.rs](daemon/src/provenance.rs) (issue #87) — on macOS a
+  `CGEventTap` reading only `kCGEventSourceStateID`, on Windows low-level hooks reading only the
+  injected-event flag — classifies each event as real-hardware vs. software-injected and counts them.
+  It never reads the key value either, and passes every event through unchanged.
 
 An auditor should confirm there is **no** branch anywhere that reads the key value. Grep recipe in
 [How to verify](#how-to-verify).
 
 ### What a minute log actually contains
-Written once per 60s at [daemon.rs:235-244](daemon/src/daemon.rs#L235):
+Written once per 60s at [daemon.rs:334-343](daemon/src/daemon.rs#L334):
 
 | Field | Example | Sensitive? |
 |-------|---------|-----------|
@@ -73,40 +76,50 @@ Written once per 60s at [daemon.rs:235-244](daemon/src/daemon.rs#L235):
 | `low_entropy` | `false` | no |
 
 The one genuinely sensitive field is `active_window_title` (it can contain document names, email
-subjects, URLs). It is captured via [daemon.rs:56-73](daemon/src/daemon.rs#L56) (`active-win-pos-rs`)
-and stored **locally**. It only ever leaves the machine if you turn on BYOK LLM scoring (§2).
+subjects, URLs). It is captured via [daemon.rs:104-121](daemon/src/daemon.rs#L104) (`active-win-pos-rs`)
+and stored **locally**. It only ever leaves the machine if you turn on BYOK LLM scoring (§2); it is
+**never** part of the signed summary uploaded to the cloud.
 
 ---
 
 ## 2. What leaves your machine (network egress inventory)
 
-The daemon's dependencies that can make network calls are `reqwest` (LLM) and `axum`/`tower-http`
-(the *inbound* localhost dashboard server). There is **no** module that syncs telemetry to a tenby10
-cloud. The complete list of outbound calls:
+Nothing leaves the machine until you **enroll** and sync. The complete list of outbound calls:
 
-1. **Your own LLM provider — opt-in, BYOK.** [llm.rs](daemon/src/llm.rs) posts directly to
+1. **tenby10 cloud sync — only when enrolled.** Once you pair a device,
+   [sync.rs](daemon/src/sync.rs) uploads to the tenby10 cloud (`cloud_base_url()`,
+   [sync.rs:16](daemon/src/sync.rs#L16), default `https://tenby10.pivotalpoint.io`). This is reached
+   only when `config.agent_id` is set (guarded in [daemon.rs](daemon/src/daemon.rs)). Three things go
+   up, and nothing else:
+   - **Signed slot summaries** (`sync_signed_slots`, `POST /api/v1/slots`): per 10-minute slot — a
+     focus score, active/idle segment counts, keystroke/click **counts**, app-category **counts**, a
+     SHA-256 **hash** of the LLM reasoning (not the text), the effective-config hash, and the
+     hash-chain link + Ed25519 signature.
+   - **Enrollment** (`enroll_with_cloud`, [sync.rs:22](daemon/src/sync.rs#L22), `POST /api/v1/enroll`):
+     your pairing token and **public** key. The private key is generated locally and never leaves the
+     keychain.
+   - **Scoring config, on change** (`upload_config_if_needed`, `POST /api/v1/config`): the effective
+     config — your auditing rules (app lists, engine mode, synthetic-detection flag) and the AI auditor
+     prompt — so a relying party can see which rubric produced each score (#62).
+
+   **Never sent:** raw keystrokes, screenshot bytes, or window titles.
+
+2. **Your own LLM provider — opt-in, BYOK.** [llm.rs](daemon/src/llm.rs) posts directly to
    `api.openai.com` ([llm.rs:35](daemon/src/llm.rs#L35)), `api.anthropic.com`
    ([llm.rs:78](daemon/src/llm.rs#L78)), or `generativelanguage.googleapis.com`
-   ([llm.rs:132](daemon/src/llm.rs#L132)) using *your* API key. This path is reached **only** when:
-   - `engine_mode == "llm"` ([daemon.rs:432](daemon/src/daemon.rs#L432)), **and**
-   - a provider **and** key are configured ([llm.rs:152-155](daemon/src/llm.rs#L152) returns `None`
-     otherwise — default config ships empty, so the default is off).
-
-   When active, the payload is the activity text (app names, **window titles**, key/click counts) —
-   built at [daemon.rs:440-449](daemon/src/daemon.rs#L440). No screenshot bytes are included (§ Gap G1).
-
-2. **Enrollment is localhost-only and mocked.** The desktop "enroll" command posts to
-   `http://127.0.0.1:{port}/api/enroll` — the daemon's own Axum server, not a remote host — and key
-   generation happens locally with `ed25519-dalek`
-   ([desktop/src-tauri/src/lib.rs:74-93](desktop/src-tauri/src/lib.rs#L74)). No cloud enrollment
-   endpoint is contacted.
+   ([llm.rs:132](daemon/src/llm.rs#L132)) using *your* API key — this goes to your provider, not to
+   tenby10. Reached **only** when `engine_mode == "llm"`
+   ([daemon.rs:570](daemon/src/daemon.rs#L570)) **and** a provider + key are configured
+   ([llm.rs:152-155](daemon/src/llm.rs#L152) returns `None` otherwise — default config ships empty, so
+   the default is off). The payload is the activity text (app names, **window titles**, key/click
+   counts) — built at [daemon.rs:577-587](daemon/src/daemon.rs#L577). No screenshot bytes (§ Gap G1).
 
 3. **Dashboard webfont — self-hosted.** The dashboard font is embedded as a `data:` URI
    ([dashboard.rs](daemon/src/dashboard.rs)); opening the local dashboard makes **no** third-party
    requests.
 
-The privacy-safe aggregated cloud payload described in the engineering spec (§5.3) is **not yet
-implemented** in this repo — there is no code that uploads focus scores anywhere.
+What the cloud receives is category- and count-level summaries plus hashes and your config — never the
+raw keystrokes, screens, or window titles behind them.
 
 ---
 
@@ -114,16 +127,18 @@ implemented** in this repo — there is no code that uploads focus scores anywhe
 
 One screenshot per 10-minute slot, blurred in memory, raw bytes dropped before anything is written.
 
-- [screen.rs:20-45](daemon/src/screen.rs#L20) — captures via the macOS `screencapture` tool to
-  stdout. If permission is denied, it generates a gray placeholder (never silently retries).
-- [screen.rs:49-54](daemon/src/screen.rs#L49) — `imageops::blur(&raw_img, 20.0)` then
-  **`drop(raw_img)`** to purge the raw buffer.
-- [screen.rs:59-66](daemon/src/screen.rs#L59) — only the blurred image is saved, as JPEG, to
+- **macOS** ([screen.rs:61-83](daemon/src/screen.rs#L61)) captures via the `screencapture` tool to
+  stdout; **Windows** ([screen.rs:89-168](daemon/src/screen.rs#L89)) via a GDI `BitBlt`. On failure it
+  **returns an error** — it does *not* fabricate a placeholder. (An earlier version substituted a gray
+  800×600 image and reported success; that was removed so a denied grant surfaces honestly and
+  `screen_capture_ok` flips false — see [daemon.rs:262-270](daemon/src/daemon.rs#L262).)
+- [screen.rs:33](daemon/src/screen.rs#L33) — `imageops::blur(&raw_img, 20.0)`, then
+  **`drop(raw_img)`** ([screen.rs:36](daemon/src/screen.rs#L36)) purges the raw buffer.
+- [screen.rs:41-47](daemon/src/screen.rs#L41) — only the blurred image is saved, as JPEG, to
   `~/.tenby10/screenshots/slot_<ts>.jpg`.
 
-The raw, unblurred image is never passed to `save`. Note: screen capture is currently
-**macOS-only** (shells out to `screencapture`); there is no Windows/Linux capture path in
-[screen.rs](daemon/src/screen.rs) yet.
+The raw, unblurred image is never passed to `save`. Capture is **macOS + Windows**; there is no Linux
+capture path yet ([screen.rs:171](daemon/src/screen.rs#L171) returns an error on other platforms).
 
 ---
 
@@ -132,14 +147,14 @@ The raw, unblurred image is never passed to `save`. Note: screen capture is curr
 All classification is isolated in one pure module so it can be read and unit-tested without the
 capture loop ([decisions/0002](../decisions/0002-activity-evaluation-engine.md)). A minute is sorted
 into exactly one state by a fixed priority order in
-[evaluator.rs:53-113](daemon/src/evaluator.rs#L53):
+[evaluator.rs:114-167](daemon/src/evaluator.rs#L114):
 
 1. **Anti-cheat first** — mouse jiggler or keyboard macro → `Tampered`
-   ([evaluator.rs:54-60](daemon/src/evaluator.rs#L54)).
+   ([evaluator.rs:115-121](daemon/src/evaluator.rs#L115)).
 2. **Distraction** — active app/title matches your `distracting_apps` list → `Distracted`
-   ([evaluator.rs:62-76](daemon/src/evaluator.rs#L62)).
+   ([evaluator.rs:123-137](daemon/src/evaluator.rs#L123)).
 3. **Active** — any keystroke, click, or scroll → `Active`
-   ([evaluator.rs:78-83](daemon/src/evaluator.rs#L78)).
+   ([evaluator.rs:139-144](daemon/src/evaluator.rs#L139)).
 4. **Meeting** — no input but the active window is a genuine meeting → `Meeting`
    (`is_meeting_context` in [evaluator.rs](daemon/src/evaluator.rs)). Matching is hardened (#97): a
    **native meeting app** by application name, a **whole-word** title keyword (so "Meeting notes" is
@@ -151,7 +166,7 @@ into exactly one state by a fixed priority order in
    `aggregate_slot` in [daemon.rs](daemon/src/daemon.rs)). The bound also holds in LLM mode: demoted
    minutes are removed from the ceiling the LLM score may claim (`meeting_creditable_ceiling`).
 5. **Passive review** — no input but a `productive_apps` app *and* you were recently active →
-   `PassiveReview` ([evaluator.rs:97-109](daemon/src/evaluator.rs#L97)).
+   `PassiveReview` ([evaluator.rs:151-163](daemon/src/evaluator.rs#L151)).
 6. **Idle** otherwise.
 
 The lists (`distracting_apps`, `productive_apps`, `meeting_apps`) are **user-configurable** and live
@@ -172,15 +187,15 @@ and bias toward never flagging a real person:
 
 **Scoring is deterministic and forgiving of thinking time:**
 - Fixed 10-minute denominator so you can't game a 100% off one active minute
-  ([daemon.rs:424](daemon/src/daemon.rs#L424), [decisions/0006](../decisions/0006-focus-score-fixed-denominator.md)).
+  ([daemon.rs:562](daemon/src/daemon.rs#L562), [decisions/0006](../decisions/0006-focus-score-fixed-denominator.md)).
 - 5-minute delayed "idle forgiveness" for reading/thinking pauses at slot boundaries
-  ([daemon.rs:369-421](daemon/src/daemon.rs#L369), [decisions/0011](../decisions/0011-contextual-idle-forgiveness.md)).
+  ([daemon.rs:503-559](daemon/src/daemon.rs#L503), [decisions/0011](../decisions/0011-contextual-idle-forgiveness.md)).
 
 **The rules are locked by tests** — read these to see the intended behavior as executable spec:
-- [evaluator.rs:175-294](daemon/src/evaluator.rs#L175) — active / passive / idle / distraction / jiggler.
-- [entropy.rs:136-181](daemon/src/entropy.rs#L136) — human vs macro keyboard, human vs jiggler mouse.
-- [daemon.rs:546-811](daemon/src/daemon.rs#L546) — full-slot aggregation, partial-slot ADR-0006,
-  idle-forgiveness approved/rejected.
+- [evaluator.rs:226-459](daemon/src/evaluator.rs#L226) — active / passive / idle / distraction / jiggler.
+- [entropy.rs:204-390](daemon/src/entropy.rs#L204) — human vs macro keyboard, human vs jiggler mouse.
+- [daemon.rs:714-1331](daemon/src/daemon.rs#L714) — full-slot aggregation, partial-slot ADR-0006,
+  idle-forgiveness approved/rejected, and the v2 config-hash binding.
 
 Run them with `cd daemon && cargo test`.
 
@@ -191,9 +206,13 @@ Run them with `cd daemon && cargo test`.
 - Everything lives under `~/.tenby10/` (or `~/.tenby10_dev/` in debug); overridable via
   `TENBY10_HOME` — see [env.rs](daemon/src/env.rs).
 - Slot summaries are hash-chained with SHA-256 over a **canonical payload covering every stored
-  field** (score, segments, keystrokes, clicks, app categories, LLM reasoning, parent link) —
-  `canonical_slot_payload` in [db.rs](daemon/src/db.rs). Hand-editing *any* field of the SQLite file
-  breaks the chain; `verify_ledger_integrity` re-derives and compares it.
+  field** (score, segments, keystrokes, clicks, app categories, LLM reasoning hash, **effective-config
+  hash**, parent link) — `canonical_slot_payload` in [db.rs](daemon/src/db.rs). Hand-editing *any* field
+  of the SQLite file breaks the chain; `verify_ledger_integrity` re-derives and compares it.
+- **The scoring rubric is bound in (v2, #62).** The payload includes a SHA-256 of the effective config
+  (your auditing rules + AI auditor prompt), so a score can't be silently divorced from the rules that
+  produced it. The exact config is uploaded on change so a relying party can inspect it. Locked by
+  `test_v2_payload_binds_config_hash` and the cross-language vector `test_v2_canonical_vector_matches_cloud`.
 - Once you enroll, each slot is also **Ed25519-signed with your key** (private key in the OS
   keychain). This closes the obvious hole in a bare hash chain: an attacker who edits a row and then
   re-computes its hash to hide the edit still cannot produce a valid signature without your key, so
@@ -215,7 +234,7 @@ real mismatches to close:
 - **G1 — Screenshots are never actually sent to any LLM, even with the toggle on.** The
   `send_screenshots` flag ([config.rs:51](daemon/src/config.rs#L51), default `false`) is only
   interpolated into the LLM system prompt as text
-  ([daemon.rs:462-476](daemon/src/daemon.rs#L462)); no image bytes are attached in
+  ([daemon.rs:600-614](daemon/src/daemon.rs#L600)); no image bytes are attached in
   [llm.rs](daemon/src/llm.rs). So the multimodal path from
   [decisions/0005](../decisions/0005-byok-screenshot-llm-transmission.md) is **not wired up**.
   *Privacy-positive today*, but the toggle is misleading — it implies a data flow that doesn't exist.
@@ -238,11 +257,14 @@ Run these from the `client/` directory. Each is designed to *fail loudly* if a c
 #    Any match binding the key (e.g. `KeyPress(key)`) is a red flag to inspect.
 grep -rn "KeyPress" daemon/src/
 
-# 2. Full outbound-network inventory. Expect ONLY llm.rs (BYOK) — the dashboard font is now inlined.
+# 2. Full outbound-network inventory. Expect llm.rs (your BYOK provider) and sync.rs (tenby10 cloud
+#    sync, only when enrolled). The dashboard font is inlined, so the dashboard makes no requests.
 grep -rniE "reqwest|\.post\(|\.get\(|https?://" daemon/src/
 
-# 3. No tenby10 cloud sync endpoint anywhere in the client.
-grep -rniE "sync|/api/v1|ingest|upload|telemetry.*(post|send)" daemon/src/
+# 3. What the cloud sync actually sends: inspect the upload payloads. Confirm they carry only counts,
+#    category counts, hashes (reasoning_hash, config_hash), the config blob, and signatures — never
+#    raw keystrokes, screenshot bytes, or window titles.
+grep -n "json!" daemon/src/sync.rs
 
 # 4. Raw screenshot is dropped, never saved: `drop(raw_img)` before any `.save`.
 grep -n "drop(raw_img)\|save_with_format\|imageops::blur" daemon/src/screen.rs

--- a/daemon/src/config.rs
+++ b/daemon/src/config.rs
@@ -59,6 +59,52 @@ pub struct AgentConfig {
     pub enforce_synthetic_detection: bool,
 }
 
+/// The scoring configuration that actually determines a slot's score — the
+/// "auditing rules" (app lists + engine + synthetic-detection) and the AI
+/// auditor prompt. Serialized in a fixed field order so the JSON blob is
+/// byte-deterministic; its SHA-256 is bound into every signed slot
+/// (config-in-ledger, #62) and the exact blob is uploaded to the cloud when it
+/// changes. Secrets and identifiers are deliberately excluded.
+#[derive(serde::Serialize)]
+pub struct EffectiveConfig<'a> {
+    pub config_scheme: u32,
+    pub engine_mode: &'a str,
+    pub distracting_apps: &'a str,
+    pub productive_apps: &'a str,
+    pub meeting_apps: &'a str,
+    pub llm_prompt: &'a str,
+    pub enforce_synthetic_detection: bool,
+}
+
+/// Versions the effective-config serialization independently of the ledger scheme.
+pub const EFFECTIVE_CONFIG_SCHEME: u32 = 1;
+
+impl AgentConfig {
+    /// Canonical JSON blob of the effective scoring config (fixed field order,
+    /// no whitespace). This is the exact string uploaded to the cloud, so the
+    /// cloud verifies it with a plain `sha256(bytes) == config_hash` — no
+    /// re-canonicalization on the server.
+    pub fn effective_config_blob(&self) -> String {
+        serde_json::to_string(&EffectiveConfig {
+            config_scheme: EFFECTIVE_CONFIG_SCHEME,
+            engine_mode: &self.engine_mode,
+            distracting_apps: &self.distracting_apps,
+            productive_apps: &self.productive_apps,
+            meeting_apps: &self.meeting_apps,
+            llm_prompt: &self.llm_prompt,
+            enforce_synthetic_detection: self.enforce_synthetic_detection,
+        })
+        .unwrap_or_default()
+    }
+
+    /// SHA-256 (lowercase hex) of [`Self::effective_config_blob`]. Bound into the
+    /// signed slot payload so every score is cryptographically tied to the rubric
+    /// that produced it.
+    pub fn effective_config_hash(&self) -> String {
+        crate::db::sha256_hex_pub(&self.effective_config_blob())
+    }
+}
+
 impl Default for AgentConfig {
     fn default() -> Self {
         Self {

--- a/daemon/src/daemon.rs
+++ b/daemon/src/daemon.rs
@@ -654,7 +654,9 @@ pub fn aggregate_slot(db: &Database, config: &crate::config::AgentConfig, slot_s
 
     // Bind the effective scoring config (auditing rules + AI prompt) into the
     // signed payload so every score is tied to the rubric that produced it (#62).
-    let config_hash = config.effective_config_hash();
+    // Compute both from the same blob so config_hash == sha256(blob), which the cloud verifies.
+    let config_blob = config.effective_config_blob();
+    let config_hash = crate::db::sha256_hex_pub(&config_blob);
 
     let slot_res = db.insert_slot_summary(
         slot_start,
@@ -683,7 +685,18 @@ pub fn aggregate_slot(db: &Database, config: &crate::config::AgentConfig, slot_s
 
     // Upload any not-yet-synced signed slots (best-effort; #115). Skips when not enrolled.
     if !config.agent_id.is_empty() {
-        match crate::sync::sync_signed_slots(db, &config.agent_id, &crate::sync::cloud_base_url()) {
+        let base = crate::sync::cloud_base_url();
+        // Send the effective config first so the slots' config_hash resolves server-side (#62).
+        if let Err(e) = crate::sync::upload_config_if_needed(
+            db,
+            &config.agent_id,
+            &base,
+            &config_blob,
+            &config_hash,
+        ) {
+            eprintln!("[Sync] {e}");
+        }
+        match crate::sync::sync_signed_slots(db, &config.agent_id, &base) {
             Ok(n) if n > 0 => println!("[Sync] Uploaded {n} slot(s) to the cloud."),
             Ok(_) => {}
             Err(e) => eprintln!("[Sync] {e}"),

--- a/daemon/src/daemon.rs
+++ b/daemon/src/daemon.rs
@@ -652,6 +652,10 @@ pub fn aggregate_slot(db: &Database, config: &crate::config::AgentConfig, slot_s
         })
     };
 
+    // Bind the effective scoring config (auditing rules + AI prompt) into the
+    // signed payload so every score is tied to the rubric that produced it (#62).
+    let config_hash = config.effective_config_hash();
+
     let slot_res = db.insert_slot_summary(
         slot_start,
         final_focus_score,
@@ -661,6 +665,7 @@ pub fn aggregate_slot(db: &Database, config: &crate::config::AgentConfig, slot_s
         slot_clicks,
         &app_categories_json,
         final_reasoning.as_deref(),
+        &config_hash,
         signer.as_ref(),
     );
 

--- a/daemon/src/db.rs
+++ b/daemon/src/db.rs
@@ -13,7 +13,8 @@ pub const BILLABLE_FOCUS_THRESHOLD: u32 = 40;
 
 /// Version of the slot signing/hashing scheme (ADR 0014). Bumped when the
 /// canonical payload format changes so old rows still verify under their scheme.
-pub const LEDGER_SCHEME_VERSION: u32 = 1;
+/// v2 (#62) binds the effective-config hash into the payload; v1 rows omit it.
+pub const LEDGER_SCHEME_VERSION: u32 = 2;
 
 /// Material needed to self-sign a slot summary (ADR 0014). Sourced from the
 /// enrolled agent's config; both keys are hex-encoded Ed25519. When absent
@@ -39,6 +40,8 @@ pub struct SignedSlot {
     pub parent_hash: String,
     pub signature: String,
     pub scheme_version: u32,
+    /// SHA-256 of the effective-config blob in force for this slot (v2+; "" for v1).
+    pub config_hash: String,
 }
 
 /// SHA-256 of a string as lowercase hex — matches the canonical payload's field folding.
@@ -87,21 +90,42 @@ fn canonical_slot_payload(
     llm_reasoning: Option<&str>,
     parent_hash: &str,
     signing_pubkey: &str,
+    config_hash: &str,
 ) -> String {
-    format!(
-        "tenby10-slot|v{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}",
-        scheme_version,
-        signing_pubkey,
-        slot_start,
-        focus_score,
-        active_segments,
-        idle_segments,
-        total_keystrokes,
-        total_clicks,
-        sha256_hex(app_categories_json),
-        sha256_hex(llm_reasoning.unwrap_or("")),
-        parent_hash,
-    )
+    // v2 (#62) inserts the effective-config hash before the parent link so every
+    // score is bound to the rubric that produced it. v1 rows keep the old format.
+    if scheme_version >= 2 {
+        format!(
+            "tenby10-slot|v{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}",
+            scheme_version,
+            signing_pubkey,
+            slot_start,
+            focus_score,
+            active_segments,
+            idle_segments,
+            total_keystrokes,
+            total_clicks,
+            sha256_hex(app_categories_json),
+            sha256_hex(llm_reasoning.unwrap_or("")),
+            config_hash,
+            parent_hash,
+        )
+    } else {
+        format!(
+            "tenby10-slot|v{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}",
+            scheme_version,
+            signing_pubkey,
+            slot_start,
+            focus_score,
+            active_segments,
+            idle_segments,
+            total_keystrokes,
+            total_clicks,
+            sha256_hex(app_categories_json),
+            sha256_hex(llm_reasoning.unwrap_or("")),
+            parent_hash,
+        )
+    }
 }
 
 /// Verify an Ed25519 slot signature. `Ok(true)`/`Ok(false)` on a well-formed
@@ -202,7 +226,8 @@ impl Database {
                 llm_reasoning TEXT,
                 signature TEXT,
                 signing_pubkey TEXT,
-                scheme_version INTEGER NOT NULL DEFAULT 1
+                scheme_version INTEGER NOT NULL DEFAULT 1,
+                config_hash TEXT NOT NULL DEFAULT ''
             )",
             [],
         )?;
@@ -229,6 +254,11 @@ impl Database {
         // Uploaded-to-cloud marker (#115). 0 = not yet synced.
         let _ = conn.execute(
             "ALTER TABLE slot_summaries ADD COLUMN synced INTEGER NOT NULL DEFAULT 0",
+            [],
+        );
+        // Config-in-ledger (#62): effective-config hash bound into v2 signed payloads.
+        let _ = conn.execute(
+            "ALTER TABLE slot_summaries ADD COLUMN config_hash TEXT NOT NULL DEFAULT ''",
             [],
         );
 
@@ -275,7 +305,7 @@ impl Database {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
             "SELECT slot_start, focus_score, active_segments, idle_segments, total_keystrokes, \
-             total_clicks, app_categories, llm_reasoning, hash, parent_hash, signature, scheme_version \
+             total_clicks, app_categories, llm_reasoning, hash, parent_hash, signature, scheme_version, config_hash \
              FROM slot_summaries \
              WHERE signature IS NOT NULL AND synced = 0 \
              ORDER BY slot_start ASC LIMIT ?1",
@@ -294,6 +324,7 @@ impl Database {
                 parent_hash: r.get(9)?,
                 signature: r.get(10)?,
                 scheme_version: r.get(11)?,
+                config_hash: r.get(12)?,
             })
         })?;
         rows.collect()
@@ -336,6 +367,7 @@ impl Database {
         total_clicks: u32,
         app_categories_json: &str,
         llm_reasoning: Option<&str>,
+        config_hash: &str,
         signer: Option<&SlotSigner>,
     ) -> Result<()> {
         let parent_hash = self.get_latest_slot_hash()?;
@@ -354,6 +386,7 @@ impl Database {
             llm_reasoning,
             &parent_hash,
             signing_pubkey,
+            config_hash,
         );
 
         let hash = sha256_hex(&payload);
@@ -372,8 +405,8 @@ impl Database {
         let conn = self.conn.lock().unwrap();
         conn.execute(
             "INSERT OR REPLACE INTO slot_summaries (
-                slot_start, focus_score, active_segments, idle_segments, total_keystrokes, total_clicks, app_categories, hash, parent_hash, llm_reasoning, signature, signing_pubkey, scheme_version
-            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
+                slot_start, focus_score, active_segments, idle_segments, total_keystrokes, total_clicks, app_categories, hash, parent_hash, llm_reasoning, signature, signing_pubkey, scheme_version, config_hash
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
             params![
                 slot_start,
                 focus_score,
@@ -387,7 +420,8 @@ impl Database {
                 llm_reasoning,
                 signature,
                 stored_pubkey,
-                LEDGER_SCHEME_VERSION
+                LEDGER_SCHEME_VERSION,
+                config_hash
             ],
         )?;
         Ok(())
@@ -482,7 +516,7 @@ impl Database {
     pub fn verify_ledger_integrity(&self, expected_pubkey: &str) -> Result<Result<(), String>> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
-            "SELECT slot_start, focus_score, active_segments, idle_segments, total_keystrokes, total_clicks, app_categories, hash, parent_hash, llm_reasoning, signature, signing_pubkey, scheme_version
+            "SELECT slot_start, focus_score, active_segments, idle_segments, total_keystrokes, total_clicks, app_categories, hash, parent_hash, llm_reasoning, signature, signing_pubkey, scheme_version, config_hash
              FROM slot_summaries ORDER BY slot_start ASC",
         )?;
         let mut rows = stmt.query([])?;
@@ -503,6 +537,7 @@ impl Database {
             let signature: Option<String> = row.get(10)?;
             let signing_pubkey: Option<String> = row.get(11)?;
             let scheme_version: u32 = row.get(12).unwrap_or(1);
+            let config_hash: String = row.get(13).unwrap_or_default();
 
             // 1. Verify parent_hash links correctly
             if parent_hash != expected_parent_hash {
@@ -526,6 +561,7 @@ impl Database {
                 llm_reasoning.as_deref(),
                 &parent_hash,
                 row_pubkey,
+                &config_hash,
             );
             let computed_hash = sha256_hex(&payload);
 
@@ -657,6 +693,7 @@ mod tests {
             20,
             "{\"coding\": 10}",
             Some("Good"),
+            "",
             None,
         )
         .unwrap();
@@ -669,6 +706,7 @@ mod tests {
             30,
             "{\"coding\": 10}",
             Some("Great"),
+            "",
             None,
         )
         .unwrap();
@@ -696,12 +734,27 @@ mod tests {
     }
 
     #[test]
+    fn test_v2_payload_binds_config_hash() {
+        let mk = |scheme: u32, cfg: &str| {
+            canonical_slot_payload(
+                scheme, 1000, 80, 8, 2, 100, 10, "{}", None, "parent", "pub", cfg,
+            )
+        };
+        // v2 folds the config hash into the signed payload, so changing it changes
+        // the bytes that are hashed and signed.
+        assert_ne!(mk(2, "cfgA"), mk(2, "cfgB"));
+        assert!(mk(2, "cfgA").contains("cfgA"));
+        // v1 rows omit the config hash entirely (back-compat): the arg is ignored.
+        assert!(!mk(1, "cfgA").contains("cfgA"));
+    }
+
+    #[test]
     fn test_unsigned_row_recompute_is_not_detected() {
         // Honest limitation (ADR 0014): with no signature, an attacker who
         // recomputes the hash after editing defeats a purely-local chain. This
         // test locks that intended scope so we don't over-claim.
         let db = create_test_db();
-        db.insert_slot_summary(1000, 50, 5, 5, 10, 2, "{}", None, None)
+        db.insert_slot_summary(1000, 50, 5, 5, 10, 2, "{}", None, "", None)
             .unwrap();
 
         let forged = canonical_slot_payload(
@@ -716,6 +769,7 @@ mod tests {
             None,
             "", // parent_hash of first row
             "", // unsigned
+            "", // config_hash
         );
         let forged_hash = sha256_hex(&forged);
         db.conn
@@ -742,9 +796,9 @@ mod tests {
             private_key: &keys.private_key,
         };
 
-        db.insert_slot_summary(1000, 80, 8, 2, 100, 10, "{}", Some("r"), Some(&signer))
+        db.insert_slot_summary(1000, 80, 8, 2, 100, 10, "{}", Some("r"), "", Some(&signer))
             .unwrap();
-        db.insert_slot_summary(1600, 90, 9, 1, 120, 12, "{}", None, Some(&signer))
+        db.insert_slot_summary(1600, 90, 9, 1, 120, 12, "{}", None, "", Some(&signer))
             .unwrap();
 
         // Valid signatures verify against the enrolled key.
@@ -775,7 +829,7 @@ mod tests {
             public_key: &keys.public_key,
             private_key: &keys.private_key,
         };
-        db.insert_slot_summary(1000, 50, 5, 5, 10, 2, "{}", None, Some(&signer))
+        db.insert_slot_summary(1000, 50, 5, 5, 10, 2, "{}", None, "", Some(&signer))
             .unwrap();
 
         // Attacker inflates focus and recomputes a matching hash (leaving the
@@ -792,6 +846,7 @@ mod tests {
             None,
             "",
             &keys.public_key,
+            "",
         );
         let forged_hash = sha256_hex(&forged);
         db.conn
@@ -833,6 +888,7 @@ mod tests {
             2,
             "{}",
             None,
+            "",
             None,
         )
         .unwrap();
@@ -846,14 +902,26 @@ mod tests {
             5,
             "{}",
             None,
+            "",
             None,
         )
         .unwrap();
         // Green slot: well above the gate -> billable.
-        db.insert_slot_summary(today_midnight + 1200, 90, 9, 1, 200, 30, "{}", None, None)
-            .unwrap();
+        db.insert_slot_summary(
+            today_midnight + 1200,
+            90,
+            9,
+            1,
+            200,
+            30,
+            "{}",
+            None,
+            "",
+            None,
+        )
+        .unwrap();
         // Fully-idle slot (focus_score 0): NOT logged, excluded from every aggregate.
-        db.insert_slot_summary(today_midnight + 1800, 0, 0, 10, 0, 0, "{}", None, None)
+        db.insert_slot_summary(today_midnight + 1800, 0, 0, 10, 0, 0, "{}", None, "", None)
             .unwrap();
 
         let (avg, active, _k, _c, scores, logged_slots, billable_slots) =

--- a/daemon/src/db.rs
+++ b/daemon/src/db.rs
@@ -261,6 +261,12 @@ impl Database {
             "ALTER TABLE slot_summaries ADD COLUMN config_hash TEXT NOT NULL DEFAULT ''",
             [],
         );
+        // Tracks which effective-config blobs have already been uploaded to the cloud (#62),
+        // so each distinct config is sent once (on change) rather than every sync.
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS synced_configs (config_hash TEXT PRIMARY KEY)",
+            [],
+        )?;
 
         Ok(())
     }
@@ -328,6 +334,24 @@ impl Database {
             })
         })?;
         rows.collect()
+    }
+
+    /// Whether an effective-config blob with this hash has already been uploaded (#62).
+    pub fn is_config_uploaded(&self, config_hash: &str) -> Result<bool> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare("SELECT 1 FROM synced_configs WHERE config_hash = ?1")?;
+        let mut rows = stmt.query(params![config_hash])?;
+        Ok(rows.next()?.is_some())
+    }
+
+    /// Record that the cloud accepted a config blob, so it is not re-uploaded.
+    pub fn mark_config_uploaded(&self, config_hash: &str) -> Result<()> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "INSERT OR IGNORE INTO synced_configs (config_hash) VALUES (?1)",
+            params![config_hash],
+        )?;
+        Ok(())
     }
 
     /// Mark a slot as uploaded so it is not sent again.
@@ -746,6 +770,32 @@ mod tests {
         assert!(mk(2, "cfgA").contains("cfgA"));
         // v1 rows omit the config hash entirely (back-compat): the arg is ignored.
         assert!(!mk(1, "cfgA").contains("cfgA"));
+    }
+
+    #[test]
+    fn test_v2_canonical_vector_matches_cloud() {
+        // Cross-language alignment vector (#62). The cloud verifier's
+        // canonicalSlotPayload() (cloud/src/lib/ledger.ts) MUST produce this exact
+        // string for the same inputs, or signatures won't verify. The same literal
+        // is asserted in the cloud's ledger.test.ts — keep both in lock-step.
+        let got = canonical_slot_payload(
+            2,
+            1000,
+            80,
+            8,
+            2,
+            100,
+            10,
+            "{}",
+            None,
+            "PARENT",
+            "PUBKEY",
+            "CONFIGHASH",
+        );
+        let expected = "tenby10-slot|v2|PUBKEY|1000|80|8|2|100|10|\
+44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a|\
+e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855|CONFIGHASH|PARENT";
+        assert_eq!(got, expected);
     }
 
     #[test]

--- a/daemon/src/sync.rs
+++ b/daemon/src/sync.rs
@@ -44,6 +44,45 @@ pub async fn enroll_with_cloud(
         .ok_or_else(|| "enrollment response had no agentId".to_string())
 }
 
+/// Upload the effective-config blob to the cloud once per distinct config (#62), so the
+/// verified page can show the rubric behind each score. The config hash is already bound into
+/// the signed slots, so the server authenticates it with `sha256(blob) == config_hash`.
+/// No-op when already uploaded, unenrolled, or the hash is empty.
+pub fn upload_config_if_needed(
+    db: &Database,
+    agent_id: &str,
+    base_url: &str,
+    config_blob: &str,
+    config_hash: &str,
+) -> Result<bool, String> {
+    if agent_id.is_empty() || config_hash.is_empty() {
+        return Ok(false);
+    }
+    if db
+        .is_config_uploaded(config_hash)
+        .map_err(|e| format!("config-sync db read failed: {e}"))?
+    {
+        return Ok(false);
+    }
+
+    let resp = reqwest::blocking::Client::new()
+        .post(format!("{base_url}/api/v1/config"))
+        .json(&serde_json::json!({
+            "agent_id": agent_id,
+            "config_hash": config_hash,
+            "config_blob": config_blob,
+        }))
+        .send()
+        .map_err(|e| format!("config upload request failed: {e}"))?;
+
+    if !resp.status().is_success() {
+        return Err(format!("config upload rejected: HTTP {}", resp.status()));
+    }
+    db.mark_config_uploaded(config_hash)
+        .map_err(|e| format!("could not mark config uploaded: {e}"))?;
+    Ok(true)
+}
+
 /// Upload not-yet-synced signed slots, oldest first, marking each on success. Stops at the
 /// first rejection (the chain must land in order). Returns the number uploaded this call.
 pub fn sync_signed_slots(db: &Database, agent_id: &str, base_url: &str) -> Result<usize, String> {

--- a/daemon/src/sync.rs
+++ b/daemon/src/sync.rs
@@ -72,6 +72,7 @@ pub fn sync_signed_slots(db: &Database, agent_id: &str, base_url: &str) -> Resul
                 "app_categories": slot.app_categories,
             },
             "reasoning_hash": sha256_hex_pub(slot.llm_reasoning.as_deref().unwrap_or("")),
+            "config_hash": slot.config_hash,
             "ledger": { "hash": slot.hash, "parent_hash": slot.parent_hash },
             "signature": slot.signature,
         });


### PR DESCRIPTION
## Summary
Bind the effective scoring config into the signed ledger (scheme v1→v2), upload it to the cloud on change, and bring AUDIT.md back in line with the code.

## Changes
- **Ledger v2** (`db.rs`): `canonical_slot_payload` folds the effective-config hash in before the parent link; v1 rows keep the old format and still verify. New `config_hash` column + migration, threaded through insert/verify.
- **Effective config** (`config.rs`): `effective_config_blob()` (fixed-order JSON of engine mode, app lists, AI prompt, synthetic-detection flag; secrets excluded) + `effective_config_hash()`.
- **Upload on change** (`sync.rs`, `daemon.rs`): `POST /api/v1/config` the first time each distinct config is seen (tracked in `synced_configs`), before the slots that reference it; `config_hash` added to the slot upload.
- **Alignment** (`db.rs` test): shared cross-language vector `test_v2_canonical_vector_matches_cloud`, byte-matched against the cloud verifier (verified live).
- **AUDIT.md**: corrected the stale/false claims — cloud sync now disclosed accurately (it previously said "nothing is sent to a tenby10 cloud"), Windows screen-capture + provenance paths, removed the gray-placeholder claim, config-in-ledger, and refreshed drifted line numbers.

## Cloud counterpart
tenby10-cloud#63 (verifier v2 + `/api/v1/config` + verified-page rubric). Ship in lock-step — a v2 client's signatures won't verify against a v1 cloud.

Closes #7