### PR TITLE
docs: add SECURITY.md with private vulnerability reporting process (#9)

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -17,6 +17,9 @@ This client is **source-available** under the PivotalPoint Source-Available Lice
 (PPSAL-1.0 — see [LICENSE](LICENSE)) — the full client that runs on your machine is readable and
 auditable; the cloud portal is not part of this repository.
 
+> **Found a vulnerability while auditing?** Please report it **privately** — see
+> [SECURITY.md](SECURITY.md). Don't open a public issue for security problems.
+
 ---
 
 ## TL;DR verdict table

--- a/README.md
+++ b/README.md
@@ -149,6 +149,12 @@ The repository utilizes GitHub Actions to ensure code quality. On every push and
 
 ---
 
+## 🔐 Security
+
+Found a vulnerability? Please report it **privately** — do not open a public issue. See [SECURITY.md](SECURITY.md) for the reporting process (GitHub private vulnerability reporting or `security@pivotalpoint.io`) and scope.
+
+---
+
 ## 🤝 Contributing
 
 Contributions are welcome! Please read our [CONTRIBUTING.md](CONTRIBUTING.md) to learn about our branch strategy, commit message rules, and software development lifecycle (SDLC) flow.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,53 @@
+# Security Policy
+
+tenby10's desktop client runs as a background process that hooks global input and captures the
+screen, so we take security reports seriously and want them to reach us **privately** before they
+reach the public.
+
+## Reporting a vulnerability
+
+**Please do not open a public GitHub issue for a suspected security vulnerability.**
+
+Use one of these private channels instead:
+
+1. **GitHub private vulnerability reporting (preferred).** On this repository, go to the **Security**
+   tab → **Report a vulnerability**. This opens a private advisory visible only to you and the
+   maintainers.
+2. **Email:** `security@pivotalpoint.io`. If you like, encrypt sensitive details or ask for a key
+   before sending them.
+
+Please include enough for us to reproduce: affected version/commit, platform (macOS/Windows),
+steps or a proof-of-concept, and the impact you observed.
+
+## What to expect
+
+- **Acknowledgement** within **3 business days**.
+- An initial assessment (and a severity estimate) within **10 business days**.
+- Progress updates as we investigate and fix, and credit in the release notes / advisory once a fix
+  ships — unless you prefer to remain anonymous.
+- We practise **coordinated disclosure**: we ask that you give us a reasonable window to release a
+  fix before any public write-up. We won't take legal action against good-faith research that
+  respects this policy and does not access, modify, or delete other people's data.
+
+## Scope
+
+**In scope** — anything in this repository:
+
+- the background telemetry **daemon** (`daemon/`),
+- the **Tauri desktop app** (`desktop/`),
+- the local dashboard and local HTTP server,
+- local key handling, the signing/hash-chain ledger, and the anti-cheat / provenance code.
+
+**Out of scope:**
+
+- The tenby10 **cloud portal / API** — it is a separate, closed-source service and is not part of
+  this repository. Report cloud issues via the same private channels above and mark them as such.
+- Vulnerabilities in **third-party dependencies** — please report those upstream; if a dependency
+  issue affects tenby10 specifically, let us know and we'll expedite the bump.
+- Findings that require a **already-compromised machine** or physical access, social engineering, or
+  denial of service against your own local instance.
+
+## Supported versions
+
+Security fixes target the **latest released version**. There are no long-term support branches;
+please reproduce on the most recent release before reporting.


### PR DESCRIPTION
## Summary
Adds a security policy so vulnerability reports reach us **privately** before they go public — a gap for a client that hooks global input and captures the screen and invites auditing (AUDIT.md).

- `SECURITY.md`: private reporting via GitHub private vulnerability reporting (preferred) or `security@pivotalpoint.io`; asks reporters not to open public issues; response-time expectations; coordinated-disclosure terms; and scope (daemon + desktop app in scope; the closed-source cloud portal and third-party deps out of scope). Supported versions = latest release.
- Linked from `README.md` (new Security section) and `AUDIT.md` (pointer near the top).

Docs only — no code or behavior changes.

## Testing
- Pre-commit gate ran the full daemon + desktop `cargo fmt` / `clippy -D warnings` / `test` suite — all green (no Rust touched).

closes #9