### PR TITLE
feat: reseal subcommand to recover an orphaned pre-sync ledger

### DIFF
--- a/daemon/src/db.rs
+++ b/daemon/src/db.rs
@@ -44,6 +44,20 @@ pub struct SignedSlot {
     pub config_hash: String,
 }
 
+/// The signable fields of a stored slot, read back for re-chaining in [`Database::reseal_from`].
+struct StoredSlotRow {
+    slot_start: i64,
+    focus_score: u32,
+    active_segments: u32,
+    idle_segments: u32,
+    total_keystrokes: u32,
+    total_clicks: u32,
+    app_categories: String,
+    llm_reasoning: Option<String>,
+    config_hash: String,
+    scheme_version: u32,
+}
+
 /// SHA-256 of a string as lowercase hex — matches the canonical payload's field folding.
 pub fn sha256_hex_pub(data: &str) -> String {
     sha256_hex(data)
@@ -354,6 +368,106 @@ impl Database {
             params![config_hash],
         )?;
         Ok(())
+    }
+
+    /// Drop every "config uploaded" marker so the next sync re-sends the effective config. Used
+    /// by [`Self::reseal_from`], where the local markers can claim a config was uploaded that the
+    /// cloud never actually received (nothing had ever synced).
+    pub fn forget_uploaded_configs(&self) -> Result<()> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute("DELETE FROM synced_configs", [])?;
+        Ok(())
+    }
+
+    /// One-shot recovery (#19): re-base the ledger suffix `slot_start >= from` into a fresh chain
+    /// under the current key so it can finally sync, and neutralize the orphaned prefix.
+    ///
+    /// Why this exists: slots captured before enrollment (unsigned) or under a rotated key leave a
+    /// chain that doesn't start at genesis and/or isn't signed by the agent's registered key. The
+    /// cloud requires a contiguous chain from `parent_hash=""` under that key, and the client
+    /// uploads oldest-first and stops at the first rejection — so the whole ledger is stuck.
+    ///
+    /// What it does, in one transaction:
+    ///   1. Marks every slot *before* `from` as `synced` so the orphaned prefix can't block the
+    ///      oldest-first sync (those slots are abandoned, never uploaded).
+    ///   2. Re-chains the `>= from` window in `slot_start` order: the first slot gets
+    ///      `parent_hash=""`, every slot is re-hashed with `signer`'s public key folded into the
+    ///      canonical payload (matching [`canonical_slot_payload`]) and re-signed, and `synced`
+    ///      is reset to 0 so the normal sync sends them.
+    ///
+    /// The stored metrics/timestamps are untouched — only the chain links, signature, and signing
+    /// key are rewritten. Returns the number of slots resealed. **Only safe before the current key
+    /// has ever successfully synced**, since it rewrites history the cloud would otherwise pin.
+    pub fn reseal_from(&self, from: i64, signer: &SlotSigner) -> Result<usize> {
+        let sk_bytes: [u8; 32] = from_hex(signer.private_key)
+            .and_then(|b| b.try_into().ok())
+            .ok_or_else(|| {
+                rusqlite::Error::InvalidParameterName("signer private_key is not 32 bytes".into())
+            })?;
+        let sk = SigningKey::from_bytes(&sk_bytes);
+
+        let conn = self.conn.lock().unwrap();
+        conn.execute_batch("BEGIN")?;
+
+        // 1. Abandon the orphaned prefix so it can never poison the oldest-first sync.
+        conn.execute(
+            "UPDATE slot_summaries SET synced = 1 WHERE slot_start < ?1",
+            params![from],
+        )?;
+
+        // 2. Load the window in chain order, then re-chain + re-sign it from genesis.
+        let rows: Vec<StoredSlotRow> = {
+            let mut stmt = conn.prepare(
+                "SELECT slot_start, focus_score, active_segments, idle_segments, total_keystrokes,
+                        total_clicks, app_categories, llm_reasoning, config_hash, scheme_version
+                 FROM slot_summaries WHERE slot_start >= ?1 ORDER BY slot_start ASC",
+            )?;
+            let mapped = stmt.query_map(params![from], |r| {
+                Ok(StoredSlotRow {
+                    slot_start: r.get(0)?,
+                    focus_score: r.get(1)?,
+                    active_segments: r.get(2)?,
+                    idle_segments: r.get(3)?,
+                    total_keystrokes: r.get(4)?,
+                    total_clicks: r.get(5)?,
+                    app_categories: r.get(6)?,
+                    llm_reasoning: r.get(7)?,
+                    config_hash: r.get(8)?,
+                    scheme_version: r.get(9)?,
+                })
+            })?;
+            mapped.collect::<Result<_>>()?
+        };
+
+        let mut parent = String::new();
+        for row in &rows {
+            let payload = canonical_slot_payload(
+                row.scheme_version,
+                row.slot_start,
+                row.focus_score,
+                row.active_segments,
+                row.idle_segments,
+                row.total_keystrokes,
+                row.total_clicks,
+                &row.app_categories,
+                row.llm_reasoning.as_deref(),
+                &parent,
+                signer.public_key,
+                &row.config_hash,
+            );
+            let hash = sha256_hex(&payload);
+            let signature = to_hex_bytes(&sk.sign(payload.as_bytes()).to_bytes());
+            conn.execute(
+                "UPDATE slot_summaries
+                 SET hash = ?1, parent_hash = ?2, signature = ?3, signing_pubkey = ?4, synced = 0
+                 WHERE slot_start = ?5",
+                params![hash, parent, signature, signer.public_key, row.slot_start],
+            )?;
+            parent = hash;
+        }
+
+        conn.execute_batch("COMMIT")?;
+        Ok(rows.len())
     }
 
     /// Mark a slot as uploaded so it is not sent again.
@@ -1253,5 +1367,144 @@ e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855|CONFIGHASH|PARE
             .export_minute_logs_csv("custom", Some(2000), Some(3000))
             .unwrap();
         assert_eq!(empty.lines().count(), 1);
+    }
+
+    /// Read a stored slot's chain columns for assertions: (parent_hash, hash, signature, pubkey, synced).
+    fn slot_chain_cols(db: &Database, slot_start: i64) -> (String, String, String, String, i64) {
+        let conn = db.conn.lock().unwrap();
+        conn.query_row(
+            "SELECT parent_hash, hash, signature, signing_pubkey, synced FROM slot_summaries WHERE slot_start = ?1",
+            params![slot_start],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get::<_, Option<String>>(2)?.unwrap_or_default(),
+                    r.get::<_, Option<String>>(3)?.unwrap_or_default(), r.get(4)?)),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_reseal_from_genesis_rechains_and_resigns_whole_ledger() {
+        let db = create_test_db();
+        let old = crate::config::generate_enrollment_keys("old");
+        let old_signer = SlotSigner {
+            public_key: &old.public_key,
+            private_key: &old.private_key,
+        };
+        // A chain signed under the OLD key (as after a re-pair that rotated the key).
+        db.insert_slot_summary(
+            1000,
+            80,
+            8,
+            2,
+            100,
+            10,
+            "{\"coding\":10}",
+            Some("a"),
+            "cfg",
+            Some(&old_signer),
+        )
+        .unwrap();
+        db.insert_slot_summary(
+            1600,
+            90,
+            9,
+            1,
+            120,
+            12,
+            "{\"coding\":10}",
+            Some("b"),
+            "cfg",
+            Some(&old_signer),
+        )
+        .unwrap();
+
+        let new = crate::config::generate_enrollment_keys("new");
+        let new_signer = SlotSigner {
+            public_key: &new.public_key,
+            private_key: &new.private_key,
+        };
+        // Reseal everything (from 0) under the new key: the whole ledger must now verify for it.
+        let n = db.reseal_from(0, &new_signer).unwrap();
+        assert_eq!(n, 2);
+        assert!(
+            db.verify_ledger_integrity(&new.public_key).unwrap().is_ok(),
+            "resealed ledger must verify under the new key"
+        );
+        assert!(
+            db.verify_ledger_integrity(&old.public_key)
+                .unwrap()
+                .is_err(),
+            "it must no longer verify under the old key"
+        );
+        // First slot is genesis; both are unsynced and signed by the new key.
+        let (p0, h0, _, k0, s0) = slot_chain_cols(&db, 1000);
+        let (p1, _, _, k1, s1) = slot_chain_cols(&db, 1600);
+        assert_eq!(p0, "", "first slot re-based to genesis");
+        assert_eq!(p1, h0, "chain links forward");
+        assert_eq!(k0, new.public_key);
+        assert_eq!(k1, new.public_key);
+        assert_eq!(
+            (s0, s1),
+            (0, 0),
+            "resealed slots are marked unsynced for upload"
+        );
+    }
+
+    #[test]
+    fn test_reseal_from_window_skips_and_neutralizes_prefix() {
+        let db = create_test_db();
+        let key = crate::config::generate_enrollment_keys("k");
+        let signer = SlotSigner {
+            public_key: &key.public_key,
+            private_key: &key.private_key,
+        };
+        // Orphaned prefix (unsigned) + an in-window suffix.
+        db.insert_slot_summary(1000, 50, 5, 5, 10, 1, "{}", None, "cfg", None)
+            .unwrap();
+        db.insert_slot_summary(1600, 60, 6, 4, 20, 2, "{}", None, "cfg", None)
+            .unwrap();
+        db.insert_slot_summary(2000, 80, 8, 2, 30, 3, "{}", None, "cfg", None)
+            .unwrap();
+        db.insert_slot_summary(2600, 90, 9, 1, 40, 4, "{}", None, "cfg", None)
+            .unwrap();
+
+        let n = db.reseal_from(2000, &signer).unwrap();
+        assert_eq!(n, 2, "only the window is resealed");
+
+        // Prefix is abandoned (marked synced so it can't block the oldest-first sync).
+        assert_eq!(slot_chain_cols(&db, 1000).4, 1);
+        assert_eq!(slot_chain_cols(&db, 1600).4, 1);
+
+        // Window is a fresh genesis chain, signed and valid under the current key.
+        let (p2000, h2000, sig2000, k2000, s2000) = slot_chain_cols(&db, 2000);
+        let (p2600, _, _, _, s2600) = slot_chain_cols(&db, 2600);
+        assert_eq!(p2000, "", "window starts at genesis");
+        assert_eq!(p2600, h2000, "window chains forward");
+        assert_eq!(k2000, key.public_key);
+        assert_eq!((s2000, s2600), (0, 0));
+
+        // The re-signature is authentic: hash == sha256(canonical) and the signature verifies.
+        let canonical = canonical_slot_payload(
+            LEDGER_SCHEME_VERSION,
+            2000,
+            80,
+            8,
+            2,
+            30,
+            3,
+            "{}",
+            None,
+            &p2000,
+            &key.public_key,
+            "cfg",
+        );
+        assert_eq!(
+            sha256_hex(&canonical),
+            h2000,
+            "hash recomputes from the resealed canonical"
+        );
+        assert!(
+            verify_slot_signature(&canonical, &sig2000, &key.public_key).unwrap(),
+            "resealed signature verifies under the current key"
+        );
     }
 }

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -9,6 +9,15 @@ use daemon::db::Database;
 async fn main() {
     let args: Vec<String> = env::args().collect();
     let is_verify = args.iter().any(|arg| arg == "--verify" || arg == "-v");
+    // `--reseal <from_unix>`: one-shot recovery of an orphaned pre-sync ledger (#19).
+    let reseal_from = args
+        .iter()
+        .position(|a| a == "--reseal")
+        .and_then(|i| args.get(i + 1))
+        .map(|v| {
+            v.parse::<i64>()
+                .expect("--reseal needs a unix timestamp argument")
+        });
 
     let app_home = daemon::env::get_app_home();
     let mut db_path = app_home.clone();
@@ -17,6 +26,13 @@ async fn main() {
     let mut config_path = app_home.clone();
     config_path.push("config.json");
     let config = daemon::config::load_config(config_path).unwrap_or_default();
+
+    if let Some(from) = reseal_from {
+        // Run the whole recovery on a plain thread: the sync path uses blocking HTTP, which must
+        // not run inside the async runtime.
+        let handle = std::thread::spawn(move || reseal_and_sync(db_path, config, from));
+        std::process::exit(handle.join().expect("reseal thread panicked"));
+    }
 
     if is_verify {
         println!("Verifying database integrity at {:?}...", db_path);
@@ -56,4 +72,82 @@ async fn main() {
 
     // Start the main loop (this blocks and runs indefinitely)
     start_daemon_loop(db, state);
+}
+
+/// One-shot `--reseal` recovery (#19): re-chain + re-sign the ledger suffix `>= from` under the
+/// current key, force the effective config to re-upload, then sync. Returns a process exit code.
+fn reseal_and_sync(
+    db_path: std::path::PathBuf,
+    config: daemon::config::AgentConfig,
+    from: i64,
+) -> i32 {
+    use daemon::db::SlotSigner;
+
+    if config.agent_id.is_empty() {
+        eprintln!("ERROR: not enrolled — nothing to reseal to.");
+        return 2;
+    }
+    if config.public_key.is_empty() || config.private_key.is_empty() {
+        eprintln!("ERROR: no signing key in config/keychain — cannot re-sign.");
+        return 2;
+    }
+
+    let db = match Database::new(db_path) {
+        Ok(db) => db,
+        Err(err) => {
+            eprintln!("ERROR: failed to open database: {err}");
+            return 2;
+        }
+    };
+
+    let signer = SlotSigner {
+        public_key: &config.public_key,
+        private_key: &config.private_key,
+    };
+    let n = match db.reseal_from(from, &signer) {
+        Ok(n) => n,
+        Err(err) => {
+            eprintln!("ERROR: reseal failed: {err}");
+            return 2;
+        }
+    };
+    println!(
+        "Resealed {n} slot(s) from {from} under key {}.",
+        config.public_key
+    );
+    if n == 0 {
+        println!("No slots in range — nothing to upload.");
+        return 0;
+    }
+
+    // The local "config uploaded" markers can lie (nothing had ever synced), so force a re-send.
+    if let Err(err) = db.forget_uploaded_configs() {
+        eprintln!("WARN: could not clear config-upload markers: {err}");
+    }
+
+    let base = daemon::sync::cloud_base_url();
+    if let Err(err) = daemon::sync::upload_config_if_needed(
+        &db,
+        &config.agent_id,
+        &base,
+        &config.effective_config_blob(),
+        &config.effective_config_hash(),
+    ) {
+        eprintln!("ERROR: config upload failed: {err}");
+        return 1;
+    }
+
+    match daemon::sync::sync_signed_slots(&db, &config.agent_id, &base) {
+        Ok(uploaded) => {
+            println!("Uploaded {uploaded} slot(s) to {base}.");
+            if let Ok(head) = db.get_latest_slot_hash() {
+                println!("Ledger head is now 0x{}", head.get(..8).unwrap_or(&head));
+            }
+            0
+        }
+        Err(err) => {
+            eprintln!("ERROR: slot sync failed: {err}");
+            1
+        }
+    }
 }


### PR DESCRIPTION
## Summary
Adds a one-shot `--reseal <from_unix>` recovery for a ledger orphaned before its first successful sync — the state left by the enrollment bugs (#17, cloud #76). It re-bases the ledger suffix into a fresh, correctly-signed chain the cloud will accept, then uploads.

## Why
Slots captured before enrollment (unsigned) or under a rotated key can't sync: the chain doesn't start at genesis and/or isn't signed by the agent's registered key, and the client uploads oldest-first and halts on the first rejection — so nothing lands.

## Implementation
- `Database::reseal_from(from, signer)` (one transaction):
  1. Marks slots `< from` as `synced` so the orphaned prefix can't block the oldest-first sync (abandoned, never uploaded).
  2. Re-chains slots `>= from` from `parent_hash=""`, re-hashing with the current pubkey folded into the canonical payload and re-signing each, `synced=0`.
  - Metrics/timestamps untouched; only chain links, signature, and signing key change.
- `Database::forget_uploaded_configs()` clears the stale local "uploaded" markers.
- `--reseal` runs reseal + forced config upload + slot sync off the async runtime (blocking HTTP), printing the new ledger head.

## Verification
- New unit tests: full-ledger reseal verifies under the new key (and no longer under the old); windowed reseal skips the prefix, re-bases the window to genesis, and the re-signature verifies + hash recomputes.
- `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` green in `daemon` and `desktop/src-tauri` (pre-commit hook).

## Caveat
Only safe **before** the current key has successfully synced (it rewrites history the cloud would otherwise pin). Used here to rescue hours stuck behind the enrollment bug.

closes #19