### PR TITLE
fix: guarantee config availability — persist blobs + backfill-on-reject

### DIFF
--- a/daemon/src/daemon.rs
+++ b/daemon/src/daemon.rs
@@ -657,6 +657,11 @@ pub fn aggregate_slot(db: &Database, config: &crate::config::AgentConfig, slot_s
     // Compute both from the same blob so config_hash == sha256(blob), which the cloud verifies.
     let config_blob = config.effective_config_blob();
     let config_hash = crate::db::sha256_hex_pub(&config_blob);
+    // Persist the blob keyed by hash so this slot (or an old one in the backlog) can be backfilled
+    // to the cloud on demand later, even after the config changes (#80).
+    if let Err(e) = db.store_config_blob(&config_hash, &config_blob) {
+        eprintln!("[Config] could not persist config blob: {e}");
+    }
 
     let slot_res = db.insert_slot_summary(
         slot_start,
@@ -683,19 +688,12 @@ pub fn aggregate_slot(db: &Database, config: &crate::config::AgentConfig, slot_s
         );
     }
 
-    // Upload any not-yet-synced signed slots (best-effort; #115). Skips when not enrolled.
+    // Upload any not-yet-synced signed slots (best-effort; #115). Skips when not enrolled. Each
+    // slot carries its config_hash; if the cloud doesn't yet have that config it rejects the slot,
+    // and sync backfills the config from the local store before retrying (#80) — no speculative
+    // pre-upload, no local "already sent" cache to go stale.
     if !config.agent_id.is_empty() {
         let base = crate::sync::cloud_base_url();
-        // Send the effective config first so the slots' config_hash resolves server-side (#62).
-        if let Err(e) = crate::sync::upload_config_if_needed(
-            db,
-            &config.agent_id,
-            &base,
-            &config_blob,
-            &config_hash,
-        ) {
-            eprintln!("[Sync] {e}");
-        }
         match crate::sync::sync_signed_slots(db, &config.agent_id, &base) {
             Ok(n) if n > 0 => println!("[Sync] Uploaded {n} slot(s) to the cloud."),
             Ok(_) => {}

--- a/daemon/src/db.rs
+++ b/daemon/src/db.rs
@@ -313,10 +313,11 @@ impl Database {
             "ALTER TABLE slot_summaries ADD COLUMN config_hash TEXT NOT NULL DEFAULT ''",
             [],
         );
-        // Tracks which effective-config blobs have already been uploaded to the cloud (#62),
-        // so each distinct config is sent once (on change) rather than every sync.
+        // The effective-config blob for every hash we've scored a slot under, so any slot can be
+        // backfilled to the cloud on demand — even after the config later changes (#80). The cloud
+        // rejects a slot whose config it lacks; we look the blob up here and upload it, then retry.
         conn.execute(
-            "CREATE TABLE IF NOT EXISTS synced_configs (config_hash TEXT PRIMARY KEY)",
+            "CREATE TABLE IF NOT EXISTS config_blobs (config_hash TEXT PRIMARY KEY, blob TEXT NOT NULL)",
             [],
         )?;
 
@@ -388,31 +389,27 @@ impl Database {
         rows.collect()
     }
 
-    /// Whether an effective-config blob with this hash has already been uploaded (#62).
-    pub fn is_config_uploaded(&self, config_hash: &str) -> Result<bool> {
-        let conn = self.conn.lock().unwrap();
-        let mut stmt = conn.prepare("SELECT 1 FROM synced_configs WHERE config_hash = ?1")?;
-        let mut rows = stmt.query(params![config_hash])?;
-        Ok(rows.next()?.is_some())
-    }
-
-    /// Record that the cloud accepted a config blob, so it is not re-uploaded.
-    pub fn mark_config_uploaded(&self, config_hash: &str) -> Result<()> {
+    /// Persist the effective-config blob for a hash so any slot referencing it can be backfilled to
+    /// the cloud on demand, even after the config later changes (#80). Idempotent; keyed by the
+    /// content hash, so re-storing the same (hash, blob) is a no-op.
+    pub fn store_config_blob(&self, config_hash: &str, blob: &str) -> Result<()> {
         let conn = self.conn.lock().unwrap();
         conn.execute(
-            "INSERT OR IGNORE INTO synced_configs (config_hash) VALUES (?1)",
-            params![config_hash],
+            "INSERT OR IGNORE INTO config_blobs (config_hash, blob) VALUES (?1, ?2)",
+            params![config_hash, blob],
         )?;
         Ok(())
     }
 
-    /// Drop every "config uploaded" marker so the next sync re-sends the effective config. Used
-    /// by [`Self::reseal_from`], where the local markers can claim a config was uploaded that the
-    /// cloud never actually received (nothing had ever synced).
-    pub fn forget_uploaded_configs(&self) -> Result<()> {
+    /// The stored effective-config blob for a hash, or `None` if we never scored a slot under it.
+    pub fn get_config_blob(&self, config_hash: &str) -> Result<Option<String>> {
         let conn = self.conn.lock().unwrap();
-        conn.execute("DELETE FROM synced_configs", [])?;
-        Ok(())
+        let mut stmt = conn.prepare("SELECT blob FROM config_blobs WHERE config_hash = ?1")?;
+        let mut rows = stmt.query(params![config_hash])?;
+        match rows.next()? {
+            Some(row) => Ok(Some(row.get(0)?)),
+            None => Ok(None),
+        }
     }
 
     /// One-shot recovery (#19): re-base the ledger suffix `slot_start >= from` into a fresh chain
@@ -1279,6 +1276,27 @@ e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855|CONFIGHASH|PARE
                 c.name
             );
         }
+    }
+
+    #[test]
+    fn test_config_blob_store_roundtrip() {
+        let db = create_test_db();
+        // Unknown hash -> None (the cloud would 428, and there'd be nothing to backfill).
+        assert_eq!(db.get_config_blob("deadbeef").unwrap(), None);
+
+        let blob = "{\"config_scheme\":2,\"aggregation_version\":1}";
+        db.store_config_blob("deadbeef", blob).unwrap();
+        assert_eq!(
+            db.get_config_blob("deadbeef").unwrap().as_deref(),
+            Some(blob)
+        );
+
+        // Idempotent: re-storing the same hash keeps the blob and does not error.
+        db.store_config_blob("deadbeef", blob).unwrap();
+        assert_eq!(
+            db.get_config_blob("deadbeef").unwrap().as_deref(),
+            Some(blob)
+        );
     }
 
     #[test]

--- a/daemon/src/db.rs
+++ b/daemon/src/db.rs
@@ -1007,14 +1007,20 @@ pub struct SlotMinuteDetailView {
 mod tests {
     use super::*;
     use std::path::PathBuf;
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::sync::atomic::{AtomicU64, Ordering};
 
+    /// A unique test-DB path per call: process id + a monotonic counter. A nanosecond timestamp
+    /// (the previous scheme) could collide under parallel test execution — two tests then shared
+    /// one SQLite file and one test's slots leaked into another's, flaking `reseal_from` counts.
     fn create_test_db() -> Database {
-        let timestamp = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
-        let path = PathBuf::from(format!("/tmp/tenby10_test_{}.db", timestamp));
+        static SEQ: AtomicU64 = AtomicU64::new(0);
+        let unique = format!(
+            "{}_{}",
+            std::process::id(),
+            SEQ.fetch_add(1, Ordering::Relaxed)
+        );
+        let path = PathBuf::from(format!("/tmp/tenby10_test_{unique}.db"));
+        let _ = std::fs::remove_file(&path); // clear any stale file (pid reuse across runs)
         Database::new(path).unwrap()
     }
 

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -120,23 +120,18 @@ fn reseal_and_sync(
         return 0;
     }
 
-    // The local "config uploaded" markers can lie (nothing had ever synced), so force a re-send.
-    if let Err(err) = db.forget_uploaded_configs() {
-        eprintln!("WARN: could not clear config-upload markers: {err}");
+    // Each resealed slot carries its own config_hash; sync backfills whichever configs the cloud
+    // is missing via the 428 retry (#80), so no config pre-upload here. Persist the current config
+    // blob so slots scored under it (the common case) can be backfilled even if they predate the
+    // local config-blob store.
+    if let Err(err) = db.store_config_blob(
+        &config.effective_config_hash(),
+        &config.effective_config_blob(),
+    ) {
+        eprintln!("WARN: could not persist current config blob: {err}");
     }
 
     let base = daemon::sync::cloud_base_url();
-    if let Err(err) = daemon::sync::upload_config_if_needed(
-        &db,
-        &config.agent_id,
-        &base,
-        &config.effective_config_blob(),
-        &config.effective_config_hash(),
-    ) {
-        eprintln!("ERROR: config upload failed: {err}");
-        return 1;
-    }
-
     match daemon::sync::sync_signed_slots(&db, &config.agent_id, &base) {
         Ok(uploaded) => {
             println!("Uploaded {uploaded} slot(s) to {base}.");

--- a/daemon/src/sync.rs
+++ b/daemon/src/sync.rs
@@ -44,33 +44,30 @@ pub async fn enroll_with_cloud(
         .ok_or_else(|| "enrollment response had no agentId".to_string())
 }
 
-/// Upload the effective-config blob to the cloud once per distinct config (#62), so the
-/// verified page can show the rubric behind each score. The config hash is already bound into
-/// the signed slots, so the server authenticates it with `sha256(blob) == config_hash`.
-/// No-op when already uploaded, unenrolled, or the hash is empty.
-pub fn upload_config_if_needed(
+/// The slots endpoint replies 428 when the referenced config isn't stored server-side yet (#80).
+const PRECONDITION_REQUIRED: u16 = 428;
+
+/// Upload the effective-config blob for `config_hash` from the local store so the cloud can
+/// interpret slots that reference it (#80). The server authenticates it with
+/// `sha256(blob) == config_hash` and stores it idempotently. Errors if we have no local blob for
+/// the hash — which shouldn't happen, since every config we score under is persisted.
+fn upload_config(
     db: &Database,
     agent_id: &str,
     base_url: &str,
-    config_blob: &str,
     config_hash: &str,
-) -> Result<bool, String> {
-    if agent_id.is_empty() || config_hash.is_empty() {
-        return Ok(false);
-    }
-    if db
-        .is_config_uploaded(config_hash)
-        .map_err(|e| format!("config-sync db read failed: {e}"))?
-    {
-        return Ok(false);
-    }
+) -> Result<(), String> {
+    let blob = db
+        .get_config_blob(config_hash)
+        .map_err(|e| format!("config-blob db read failed: {e}"))?
+        .ok_or_else(|| format!("no local config blob for {config_hash}"))?;
 
     let resp = reqwest::blocking::Client::new()
         .post(format!("{base_url}/api/v1/config"))
         .json(&serde_json::json!({
             "agent_id": agent_id,
             "config_hash": config_hash,
-            "config_blob": config_blob,
+            "config_blob": blob,
         }))
         .send()
         .map_err(|e| format!("config upload request failed: {e}"))?;
@@ -78,13 +75,37 @@ pub fn upload_config_if_needed(
     if !resp.status().is_success() {
         return Err(format!("config upload rejected: HTTP {}", resp.status()));
     }
-    db.mark_config_uploaded(config_hash)
-        .map_err(|e| format!("could not mark config uploaded: {e}"))?;
-    Ok(true)
+    Ok(())
 }
 
-/// Upload not-yet-synced signed slots, oldest first, marking each on success. Stops at the
-/// first rejection (the chain must land in order). Returns the number uploaded this call.
+/// Build the ADR-0014 slot upload payload. Only the SHA-256 of `llm_reasoning` is sent.
+fn slot_payload(agent_id: &str, slot: &crate::db::SignedSlot) -> serde_json::Value {
+    serde_json::json!({
+        "agent_id": agent_id,
+        "scheme_version": slot.scheme_version,
+        "slot_start": slot.slot_start,
+        "metrics": {
+            "focus_score": slot.focus_score,
+            "active_segments": slot.active_segments,
+            "idle_segments": slot.idle_segments,
+            "total_keystrokes": slot.total_keystrokes,
+            "total_clicks": slot.total_clicks,
+            "app_categories": slot.app_categories,
+        },
+        "reasoning_hash": sha256_hex_pub(slot.llm_reasoning.as_deref().unwrap_or("")),
+        "config_hash": slot.config_hash,
+        "ledger": { "hash": slot.hash, "parent_hash": slot.parent_hash },
+        "signature": slot.signature,
+    })
+}
+
+/// Upload not-yet-synced signed slots, oldest first, marking each on success. Stops at the first
+/// rejection (the chain must land in order). Returns the number uploaded this call.
+///
+/// If the cloud rejects a slot because it doesn't yet hold the referenced config (428), we upload
+/// that config from the local store and retry the slot once (#80). Config presence is therefore
+/// guaranteed before a slot lands — a verified link can never reference a rubric/version the cloud
+/// can't resolve — with no speculative pre-upload and no local "already sent" cache to go stale.
 pub fn sync_signed_slots(db: &Database, agent_id: &str, base_url: &str) -> Result<usize, String> {
     if agent_id.is_empty() {
         return Ok(0);
@@ -98,29 +119,21 @@ pub fn sync_signed_slots(db: &Database, agent_id: &str, base_url: &str) -> Resul
     let mut uploaded = 0usize;
 
     for slot in slots {
-        let payload = serde_json::json!({
-            "agent_id": agent_id,
-            "scheme_version": slot.scheme_version,
-            "slot_start": slot.slot_start,
-            "metrics": {
-                "focus_score": slot.focus_score,
-                "active_segments": slot.active_segments,
-                "idle_segments": slot.idle_segments,
-                "total_keystrokes": slot.total_keystrokes,
-                "total_clicks": slot.total_clicks,
-                "app_categories": slot.app_categories,
-            },
-            "reasoning_hash": sha256_hex_pub(slot.llm_reasoning.as_deref().unwrap_or("")),
-            "config_hash": slot.config_hash,
-            "ledger": { "hash": slot.hash, "parent_hash": slot.parent_hash },
-            "signature": slot.signature,
-        });
-
-        let resp = client
+        let payload = slot_payload(agent_id, &slot);
+        let mut resp = client
             .post(&url)
             .json(&payload)
             .send()
             .map_err(|e| format!("slot upload request failed: {e}"))?;
+
+        if resp.status().as_u16() == PRECONDITION_REQUIRED {
+            upload_config(db, agent_id, base_url, &slot.config_hash)?;
+            resp = client
+                .post(&url)
+                .json(&payload)
+                .send()
+                .map_err(|e| format!("slot re-upload after config backfill failed: {e}"))?;
+        }
 
         if !resp.status().is_success() {
             return Err(format!(


### PR DESCRIPTION
Closes #25.

Guarantees the cloud can always resolve the config behind a signed slot, by making config availability a backfill-on-demand invariant instead of relying on a local "already uploaded" cache.

## Changes
- **Persist config blobs by hash** (`config_blobs` table): every effective-config blob we score a slot under is stored locally, so any slot — a backlog one, or a resealed one under a since-changed config — can be re-supplied to the cloud on demand. Replaces the `synced_configs` upload-marker cache (which could claim a config was sent that the cloud never received).
- **Reject-and-retry sync** (`sync_signed_slots`): the cloud replies `428` when it doesn't yet hold a slot's config; we upload that config from the store and retry the slot once. No speculative pre-upload, no stale cache.
- **Reseal**: drops the forget-markers dance; the 428 retry backfills whatever the cloud is missing, and the current blob is persisted so an unchanged-config reseal backfills cleanly.
- **Test isolation**: `create_test_db` now names DB files by process id + a monotonic counter instead of a nanosecond timestamp, so parallel tests can't collide on one SQLite file (that flaked `test_reseal_from_genesis` on CI).

## Verification
`cargo test` 71 passed / 0 failed (adds `test_config_blob_store_roundtrip`); `cargo fmt --check` and `cargo clippy -- -D warnings` clean.

Per ADR 0017 (the config blob now also carries the aggregation-semantics version, so a missing blob must never leave a slot uninterpretable).
