### PR TITLE
fix: refresh capture health promptly instead of only at slot boundaries

### DIFF
--- a/daemon/src/daemon.rs
+++ b/daemon/src/daemon.rs
@@ -23,8 +23,12 @@ pub struct TelemetryState {
     pub input_listener_alive: AtomicBool,
     /// Unix-ms timestamp of the last input event actually observed (0 = none yet).
     pub last_input_event_ms: AtomicI64,
-    /// Whether the most recent screenshot attempt was a real capture (not a denial fallback).
+    /// Whether the most recent capture attempt — a real slot screenshot or a
+    /// [`probe`](crate::screen::probe_capture) — actually succeeded.
     pub screen_capture_ok: AtomicBool,
+    /// Unix-ms timestamp of the last capture attempt of either kind (0 = none yet).
+    /// Throttles [`TelemetryState::refresh_screen_capture_health`].
+    pub last_capture_check_ms: AtomicI64,
 }
 
 /// Rolling anti-automation window sizes (ADR 0002 addendum). Anti-automation
@@ -33,6 +37,29 @@ pub struct TelemetryState {
 /// recent N samples and bound memory by trimming the oldest.
 const KEY_INTERVAL_WINDOW: usize = 256;
 const MOUSE_POSITION_WINDOW: usize = 512;
+
+/// Minimum gap between ground-truth capture probes (issue #6). The settings UI
+/// polls capture health every 10s and each probe spawns a real screen grab, so
+/// this throttles the cost while staying 20x fresher than the 10-minute slot
+/// cadence that used to be the only thing moving the flag.
+const CAPTURE_PROBE_MIN_GAP_MS: i64 = 30_000;
+
+/// Whether a fresh capture probe is due. Split out from the probe itself so the
+/// throttle is testable on CI, where a real screen capture cannot run.
+fn capture_probe_due(last_check_ms: i64, now_ms: i64) -> bool {
+    // Never checked yet, or the clock jumped backwards (sleep/timezone) — probe.
+    last_check_ms == 0
+        || now_ms < last_check_ms
+        || now_ms - last_check_ms >= CAPTURE_PROBE_MIN_GAP_MS
+}
+
+/// Current wall-clock time in Unix milliseconds.
+fn now_unix_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
 
 /// Keep only the most recent `max` elements of `v`, dropping the oldest.
 fn trim_front<T>(v: &mut Vec<T>, max: usize) {
@@ -64,7 +91,33 @@ impl TelemetryState {
             input_listener_alive: AtomicBool::new(false),
             last_input_event_ms: AtomicI64::new(0),
             screen_capture_ok: AtomicBool::new(false),
+            last_capture_check_ms: AtomicI64::new(0),
         }
+    }
+
+    /// Record the outcome of a capture attempt (probe or real slot screenshot)
+    /// and reset the probe throttle, so the two paths keep one shared clock.
+    pub fn record_capture_result(&self, ok: bool, now_ms: i64) {
+        self.screen_capture_ok.store(ok, Ordering::Relaxed);
+        self.last_capture_check_ms.store(now_ms, Ordering::Relaxed);
+    }
+
+    /// Re-derive `screen_capture_ok` from an actual capture attempt, throttled to
+    /// at most one probe per [`CAPTURE_PROBE_MIN_GAP_MS`]. Returns the freshest
+    /// value known.
+    ///
+    /// Without this the flag only moves at 10-minute slot boundaries, so a revoked
+    /// Screen Recording grant keeps reading as healthy for up to 10 minutes — the
+    /// "green but not capturing" window in issue #6. Blocking (it spawns a real
+    /// capture); call it off the UI thread.
+    pub fn refresh_screen_capture_health(&self) -> bool {
+        let now_ms = now_unix_ms();
+        if !capture_probe_due(self.last_capture_check_ms.load(Ordering::Relaxed), now_ms) {
+            return self.screen_capture_ok.load(Ordering::Relaxed);
+        }
+        let ok = crate::screen::probe_capture().is_ok();
+        self.record_capture_result(ok, now_ms);
+        ok
     }
 
     /// Reset the per-minute counters for the next minute slot. The rolling
@@ -205,6 +258,20 @@ pub fn start_daemon_loop(db: Arc<Database>, state: Arc<TelemetryState>) {
     // Run catch-up aggregation immediately at startup
     aggregate_pending_slots(&db);
 
+    // Seed capture health from a real probe rather than leaving it at the
+    // pessimistic startup default. Without this the UI reports "Not capturing"
+    // until the first slot boundary — up to 10 minutes of a false red on a
+    // perfectly healthy machine, and a false green after a mid-run revocation
+    // once the first capture has succeeded (issue #6).
+    if state.refresh_screen_capture_health() {
+        println!("[Screen] Startup capture probe succeeded.");
+    } else {
+        eprintln!(
+            "[Screen Warning] Startup capture probe failed; Screen Recording is likely \
+             not granted. Screenshots will not be captured until it is."
+        );
+    }
+
     let mut last_screenshot_slot_start: Option<i64> = None;
 
     loop {
@@ -259,9 +326,9 @@ pub fn start_daemon_loop(db: Arc<Database>, state: Arc<TelemetryState>) {
             screenshots_dir.push("screenshots");
 
             match crate::screen::capture_and_blur_screenshot(screenshots_dir, finished_slot) {
-                Ok(_) => state.screen_capture_ok.store(true, Ordering::Relaxed),
+                Ok(_) => state.record_capture_result(true, now_unix_ms()),
                 Err(err) => {
-                    state.screen_capture_ok.store(false, Ordering::Relaxed);
+                    state.record_capture_result(false, now_unix_ms());
                     eprintln!(
                         "[Screen Warning] Screen capture failed for slot {}: {}. \
                          Screenshots will NOT be captured until Screen Recording is granted.",
@@ -713,6 +780,61 @@ mod tests {
 
     use std::sync::atomic::{AtomicUsize, Ordering};
     static DB_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+    #[test]
+    fn test_capture_probe_due_throttles_within_the_gap() {
+        let now = 1_000_000_000_000;
+        assert!(
+            capture_probe_due(0, now),
+            "never checked -> probe immediately"
+        );
+        assert!(
+            !capture_probe_due(now - 1, now),
+            "just checked -> do not re-probe"
+        );
+        assert!(
+            !capture_probe_due(now - (CAPTURE_PROBE_MIN_GAP_MS - 1), now),
+            "inside the throttle window -> do not re-probe"
+        );
+        assert!(
+            capture_probe_due(now - CAPTURE_PROBE_MIN_GAP_MS, now),
+            "at the gap -> probe"
+        );
+        assert!(
+            capture_probe_due(now - (CAPTURE_PROBE_MIN_GAP_MS * 20), now),
+            "long past the gap -> probe"
+        );
+    }
+
+    #[test]
+    fn test_capture_probe_due_survives_a_backwards_clock() {
+        // Sleep/wake or a timezone change can move the wall clock backwards. A
+        // naive `now - last >= gap` would then never fire again, freezing capture
+        // health at whatever it last read (issue #6).
+        let now = 1_000_000_000_000;
+        assert!(
+            capture_probe_due(now + 60_000, now),
+            "clock jumped backwards -> probe rather than latch"
+        );
+    }
+
+    #[test]
+    fn test_record_capture_result_updates_flag_and_throttle_clock() {
+        let state = TelemetryState::new();
+        assert!(
+            !state.screen_capture_ok.load(Ordering::Relaxed),
+            "starts pessimistic"
+        );
+
+        state.record_capture_result(true, 5_000);
+        assert!(state.screen_capture_ok.load(Ordering::Relaxed));
+        assert_eq!(state.last_capture_check_ms.load(Ordering::Relaxed), 5_000);
+
+        // A failing slot capture must flip the flag back, not just go unnoticed.
+        state.record_capture_result(false, 9_000);
+        assert!(!state.screen_capture_ok.load(Ordering::Relaxed));
+        assert_eq!(state.last_capture_check_ms.load(Ordering::Relaxed), 9_000);
+    }
 
     fn create_test_db() -> Database {
         let count = DB_COUNTER.fetch_add(1, Ordering::Relaxed);

--- a/daemon/src/screen.rs
+++ b/daemon/src/screen.rs
@@ -20,6 +20,22 @@ pub fn capture_and_blur_screenshot(
     blur_and_save(raw_img, screenshots_dir, slot_start)
 }
 
+/// Ground-truth health probe: attempt a real capture and immediately discard the
+/// pixels. Nothing is blurred, saved, or returned — the raw buffer is dropped
+/// before this function returns, so probing never writes an image to disk.
+///
+/// Needed because neither available signal is trustworthy on its own: the TCC
+/// preflight (`CGPreflightScreenCaptureAccess`) keeps returning a cached `true`
+/// after a grant is revoked, and the real slot capture only runs once per
+/// 10 minutes — so a broken capture can read as healthy for that long (issue #6).
+/// Actually trying is the only way to know now.
+pub fn probe_capture() -> Result<(), String> {
+    let raw_img = capture_raw_image()?;
+    // Explicitly purge the raw capture: a probe only wants the success/failure.
+    drop(raw_img);
+    Ok(())
+}
+
 /// Shared privacy pipeline: blur the raw capture in memory, **drop the raw
 /// buffer**, and write only the blurred image as a low-resolution JPEG. The raw,
 /// unblurred image is never passed to `save`. Platform-independent so the same
@@ -238,5 +254,29 @@ mod tests {
         );
 
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// On-device check for the capture-health probe (issue #6). Like the capture
+    /// smoke test above it needs a real display + screen-recording permission, so
+    /// it is ignored on CI:
+    ///
+    /// ```text
+    /// cargo test -p daemon -- --ignored probe_capture
+    /// ```
+    #[test]
+    #[ignore = "captures the real screen; needs a display + screen-recording permission"]
+    fn test_probe_capture_succeeds_and_writes_nothing() {
+        let before = std::env::temp_dir().join("tenby10_probe_should_not_appear.jpg");
+        std::fs::remove_file(&before).ok();
+
+        probe_capture().expect("probe should succeed on a permitted device");
+
+        // The probe must be side-effect free: it exists to answer a yes/no, and
+        // must never leave an image behind (it does not blur, so anything it wrote
+        // would be a raw screenshot on disk).
+        assert!(
+            !before.exists(),
+            "probe_capture must not write any image to disk"
+        );
     }
 }

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -326,12 +326,22 @@ async fn get_capture_health(
     let last_ms = state.last_input_event_ms.load(Ordering::Relaxed);
     let input_idle_ms = if last_ms == 0 { -1 } else { now_ms - last_ms };
 
+    // Re-derive screen health from a real capture attempt instead of reading a flag
+    // that otherwise only moves at 10-minute slot boundaries (issue #6). The probe
+    // is internally throttled, so polling this command every 10s is cheap; it
+    // spawns a capture, so it runs on the blocking pool rather than the UI thread.
+    let probe_state = state.inner().clone();
+    let screen_capture_ok =
+        tauri::async_runtime::spawn_blocking(move || probe_state.refresh_screen_capture_health())
+            .await
+            .map_err(|err| format!("Capture health probe failed to run: {}", err))?;
+
     Ok(CaptureHealth {
         input_listener_alive: state.input_listener_alive.load(Ordering::Relaxed),
         // Consider input "recently seen" if an event arrived in the last 5 seconds.
         input_recently_seen: (0..=5_000).contains(&input_idle_ms),
         input_idle_ms,
-        screen_capture_ok: state.screen_capture_ok.load(Ordering::Relaxed),
+        screen_capture_ok,
     })
 }
 

--- a/desktop/src/main.js
+++ b/desktop/src/main.js
@@ -454,11 +454,26 @@ listen("tracking-status-changed", (event) => {
 async function checkPermissionsStatus() {
   try {
     const status = await invoke("check_permissions");
-    
+
+    // macOS caches the Screen Recording preflight: CGPreflightScreenCaptureAccess
+    // keeps returning true after the grant is revoked. Cross-check it against
+    // ground truth (a real capture attempt) so a stale-green permission can never
+    // read as "Granted" while capture is actually failing (issue #6).
+    let screenRecordingGranted = status.screen_recording;
+    if (screenRecordingGranted) {
+      try {
+        const health = await invoke("get_capture_health");
+        if (!health.screen_capture_ok) screenRecordingGranted = "stale";
+      } catch {
+        // Health unavailable — leave the preflight answer as-is rather than
+        // inventing a failure.
+      }
+    }
+
     // Update individual status tags
     updatePermissionStatusUI("perm-input-monitoring-status", status.input_monitoring);
     updatePermissionStatusUI("perm-accessibility-status", status.accessibility);
-    updatePermissionStatusUI("perm-screen-recording-status", status.screen_recording);
+    updatePermissionStatusUI("perm-screen-recording-status", screenRecordingGranted);
     updatePermissionStatusUI("perm-automation-status", status.automation);
 
     // Hide permissions tab completely if the OS doesn't require explicit permissions (Windows/Linux)
@@ -474,7 +489,9 @@ async function checkPermissionsStatus() {
       if (!status.requires_permissions) {
         alertBanner.style.display = "none";
       } else {
-        const anyMissing = !status.input_monitoring || !status.accessibility || !status.screen_recording || !status.automation;
+        // `screenRecordingGranted !== true` also catches the stale-green case, so a
+        // machine that is silently not capturing still raises the banner.
+        const anyMissing = !status.input_monitoring || !status.accessibility || screenRecordingGranted !== true || !status.automation;
         alertBanner.style.display = anyMissing ? "flex" : "none";
       }
     }
@@ -514,11 +531,11 @@ async function checkCaptureHealth() {
       if (health.screen_capture_ok) {
         screenStatus.innerText = "Capturing";
         screenStatus.className = "status-indicator granted";
-        screenDetail.innerText = "Last screenshot was a real capture.";
+        screenDetail.innerText = "A real capture succeeded — checked live, not just at the 10-minute slot boundary.";
       } else {
         screenStatus.innerText = "Not capturing";
         screenStatus.className = "status-indicator denied";
-        screenDetail.innerText = "Last screenshot attempt failed — grant Screen Recording and restart tenby10. (Shows once the first slot completes.)";
+        screenDetail.innerText = "A capture attempt just failed — grant Screen Recording, then fully quit and relaunch tenby10.";
       }
     }
   } catch (err) {
@@ -526,15 +543,23 @@ async function checkCaptureHealth() {
   }
 }
 
+// `isGranted` is a boolean, or the string "stale" for a permission the OS reports
+// as granted while a real capture attempt just failed (issue #6).
 function updatePermissionStatusUI(elementId, isGranted) {
   const el = document.getElementById(elementId);
   if (!el) return;
-  if (isGranted) {
+  if (isGranted === "stale") {
+    el.innerText = "Not capturing";
+    el.className = "status-indicator denied";
+    el.title = "macOS reports this permission as granted, but capture is failing right now. Re-grant Screen Recording, then fully quit and relaunch tenby10.";
+  } else if (isGranted) {
     el.innerText = "Granted";
     el.className = "status-indicator granted";
+    el.title = "";
   } else {
     el.innerText = "Denied";
     el.className = "status-indicator denied";
+    el.title = "";
   }
 }
 


### PR DESCRIPTION
## Summary
Closes the "green but not capturing" window: the app could report screen capture as healthy while nothing was actually being captured.

## The two stale signals
- `CGPreflightScreenCaptureAccess()` returns a **cached `true`** after the Screen Recording grant is revoked — the permission light stays green.
- `screen_capture_ok` only moved when a screenshot was *attempted*, i.e. once per 10-minute slot. So it could read stale-`true` for up to 10 minutes after capture broke — and stale-`false` for up to 10 minutes at startup on a perfectly healthy machine.

## Approach — stop inferring, actually try
- **`screen::probe_capture()`** attempts a real capture and drops the pixels immediately. It does not blur, save, or return an image; a probe only answers yes/no, so nothing lands on disk (it skips the blur step, so anything written *would* be a raw screenshot — hence the explicit no-write assertion in its test).
- **`TelemetryState::refresh_screen_capture_health()`** re-probes, throttled to one attempt per 30s. The UI polls health every 10s, so this bounds cost while being **20x fresher** than the slot cadence. Real slot captures record through the same `record_capture_result` clock, so the two paths share one throttle and never double-probe.
- **Startup probe** — health is correct immediately instead of pessimistic-red until the first slot completes.
- **`get_capture_health`** refreshes on demand, on the blocking pool (a probe spawns a capture), rather than reading a possibly-stale atomic.

## UI cross-check
The Screen Recording permission row no longer trusts the preflight alone. When macOS claims *granted* but a capture just failed it renders **"Not capturing"** with a tooltip explaining the re-grant + relaunch, and that state also raises the permissions banner. Corrected the stale detail copy that said the status only "shows once the first slot completes".

## Verification
- `cargo fmt` / `clippy -D warnings` / `cargo test` green in **both** crates; daemon now at **74 passing** (+3 new).
- New CI-safe unit tests cover the throttle, including a **backwards clock jump** (sleep/wake or timezone change) which a naive `now - last >= gap` would latch off forever.
- Ran the new on-device probe test locally: it correctly reported `screencapture produced no output ... Screen Recording permission is likely denied` — i.e. **the probe detects denial rather than faking success**, which is exactly the failure this issue is about. As a control, the pre-existing `capture_real_screen` test fails identically and bare `screencapture` also fails for this terminal, confirming that is a TCC grant missing in my shell, not a regression.
- `main.js` parses cleanly as an ES module.

**Not verified end-to-end here**: watching the light actually flip after a live mid-session revocation needs a permitted GUI session and `tccutil` grant juggling. Worth a manual pass via `scripts/dev_bundle.sh` before release — the probe's denial path is proven, the success path rides the same `capture_raw_image()` already covered by the existing smoke test.

closes #6
