### PR TITLE
chore: retire the unused loopback dashboard HTTP server

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -36,6 +36,7 @@ auditable; the cloud portal is not part of this repository.
 | 8 | Local logs are tamper-evident (full-payload hash chain) + self-signed when enrolled | ✅ Verified | [db.rs `insert_slot_summary`/`verify_ledger_integrity`](daemon/src/db.rs) |
 | — | Secrets stored in OS keychain | ✅ Verified | [config.rs `save_config`/`load_config`](daemon/src/config.rs) — `private_key` & `llm_api_key` kept in the OS keychain via the `keyring` crate |
 | — | Local dashboard makes no third-party calls | ✅ Verified | [dashboard.rs](daemon/src/dashboard.rs) — Outfit font embedded as a data URI; no CDN `<link>` |
+| — | The installed app opens **no listening port** | ✅ Verified | The dashboard renders in-app over Tauri IPC. The loopback HTTP server is a debug-only escape hatch for the standalone `daemon` binary, off unless `TENBY10_DEBUG_HTTP` is set — [env.rs `debug_http_enabled`](daemon/src/env.rs) |
 
 Bottom line: the core privacy claims — **no keylogging, and your raw keystrokes, screenshots, and
 window titles never leave the machine** — hold up against the code. When you enroll and sync, signed

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Everything is stored locally under `~/.tenby10/`. If you enroll a device, only s
 *   ⏱️ **Passive, Zero-Friction Tracking**: The background daemon automatically logs active application and window states. Includes a convenient Pause/Resume toggle switch in the system tray and settings UI to control when tracking is active.
 *   🔒 **Local-First & Sandbox Storage**: All minute logs, configuration files, and screen captures are stored strictly on your machine under `~/.tenby10/`.
     - **Development Mode**: When running from source in debug mode, the app automatically isolates itself to `~/.tenby10_dev/`.
-    - **Environment Overrides**: Use `TENBY10_HOME` to override the base directory and `TENBY10_PORT` to override the dashboard port (default: 5005).
+    - **Environment Overrides**: Use `TENBY10_HOME` to override the base directory. `TENBY10_DEBUG_HTTP` opts the standalone daemon into a loopback debug server (off by default), and `TENBY10_PORT` sets its port (default: 5005).
 *   🛡️ **Tamper-Evident Ledger**: Each 10-minute slot summary is SHA-256 hash-chained over its **full** payload, so editing any stored field breaks the chain. Once you enroll, every slot is additionally **Ed25519-signed with your key**, so even a re-computed hash won't verify without that key. On a machine you control this is tamper-*evidence* and self-asserted authorship — not, by itself, third-party proof.
 *   🧠 **BYOK Local AI Scribe**: Connects directly to your own provider (OpenAI, Anthropic, or Gemini) to analyze active logs and generate professional work summaries. 
 *   🟢 **10-Minute Slot Standard**: Records your day in verifiable 10-minute slots, each hash-chained and — once you enroll — signed with your key.
@@ -43,17 +43,17 @@ The codebase is structured as a lightweight monorepo containing two core compone
                   │   - Screen Blur Capture (10m slot random)    │
                   │   - Local DB & Cryptographic Ledger          │
                   └──────────────┬───────────────────────────────┘
-                                 │ Serves localhost:5005
+                                 │ Tauri IPC (no network)
                                  ▼
                   ┌──────────────────────────────────────────────┐
-                  │             Analytics Dashboard              │
-                  │   - HTML5 / CSS3 local dashboard UI          │
+                  │      Analytics Dashboard (in-app view)       │
+                  │   - Renders inside the app window            │
                   │   - Interactive focus entropy graphs         │
                   │   - Blurred timeline screen browser          │
                   └──────────────────────────────────────────────┘
 ```
 
-1.  **Background Daemon (`/daemon`)**: A background service written in Rust that handles global OS input hooks, scrapes active window titles at a 10s interval, processes Gaussian blurred screenshots, maintains the local SQLite database (`tenby10.db`), and exposes a local Axum HTTP server at `localhost:5005`.
+1.  **Background Daemon (`/daemon`)**: A background service written in Rust that handles global OS input hooks, scrapes active window titles at a 10s interval, processes Gaussian blurred screenshots, and maintains the local SQLite database (`tenby10.db`). **The installed app opens no network port** — the dashboard reads from the daemon over Tauri IPC. A loopback HTTP server exists in the codebase purely as a debugging escape hatch for the standalone `daemon` binary, and stays off unless `TENBY10_DEBUG_HTTP` is explicitly set.
 2.  **Desktop GUI (`/desktop`)**: A native desktop wrapper built using **Tauri (v2)** with a frosted glassmorphism settings interface, enabling cryptographic key enrollment and configuration management.
 
 ---
@@ -90,8 +90,13 @@ cd daemon
 # Build daemon binaries
 cargo build --release
 
-# Run daemon manually (spawns the Axum local dashboard server on http://localhost:5005)
+# Run daemon manually (opens no network port)
 cargo run
+
+# Optional: also start the loopback debug dashboard for triage. It is
+# unauthenticated — anything that can reach loopback on this machine can read the
+# blurred screenshots and activity CSV it serves — so leave it off by default.
+TENBY10_DEBUG_HTTP=1 cargo run   # then open http://localhost:5005
 ```
 
 ### 2. Build and Run the Tauri Desktop App

--- a/daemon/src/dashboard.rs
+++ b/daemon/src/dashboard.rs
@@ -2,20 +2,27 @@ use axum::{
     Json, Router,
     extract::State,
     response::{Html, IntoResponse},
-    routing::{get, post},
+    routing::get,
 };
 use base64::{Engine as _, engine::general_purpose};
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::net::TcpListener;
-use tower_http::cors::CorsLayer;
 
 use crate::db::Database;
 
 // Icon will be included and encoded at runtime
 
-/// Start the Axum web server on a background thread.
+/// Start the debug HTTP dashboard on a background thread, bound to loopback.
+///
+/// **Not started by the installed app** (#40). The activity dashboard renders
+/// in-app from Tauri IPC, so this exists only as a triage escape hatch for the
+/// standalone `daemon` binary, gated behind [`crate::env::debug_http_enabled`].
+///
+/// It is unauthenticated: while enabled, anything that can reach loopback — any
+/// local process or OS user on the machine — can read the blurred screenshots and
+/// the activity CSV it serves. Keep it off unless actively debugging.
 pub fn start_dashboard_server(db: Arc<Database>, port: u16) {
     let db_state = Arc::clone(&db);
 
@@ -29,19 +36,24 @@ pub fn start_dashboard_server(db: Arc<Database>, port: u16) {
             let mut screenshots_dir = crate::env::get_app_home();
             screenshots_dir.push("screenshots");
 
+            // Read-only triage surface. The config read/write and mock-enroll routes
+            // were removed (#40): they mutated state — including secret-bearing
+            // config — over an unauthenticated port, and had no diagnostic value now
+            // that the app configures itself over Tauri IPC.
+            //
+            // No CORS layer either. This previously ran `CorsLayer::permissive()`,
+            // which let any origin read these responses; the dashboard HTML is served
+            // from this same origin and needs no cross-origin access.
             let app = Router::new()
                 .route("/", get(serve_dashboard_html))
                 .route("/api/data", get(get_dashboard_data))
                 .route("/api/pending", get(get_pending_slots))
                 .route("/api/slot_details", get(get_slot_details))
                 .route("/api/export", get(export_csv))
-                .route("/api/settings", get(get_settings).post(save_settings))
-                .route("/api/enroll", post(mock_cloud_enroll))
                 .nest_service(
                     "/screenshots",
                     tower_http::services::ServeDir::new(screenshots_dir),
                 )
-                .layer(CorsLayer::permissive())
                 .with_state(db_state);
 
             let addr = SocketAddr::from(([127, 0, 0, 1], port));
@@ -155,23 +167,11 @@ async fn export_csv(
     (headers, csv_data).into_response()
 }
 
-async fn get_settings() -> impl IntoResponse {
-    let mut config_path = crate::env::get_app_home();
-    config_path.push("config.json");
-
-    let config = crate::config::load_config(config_path).unwrap_or_default();
-    Json(config).into_response()
-}
-
-async fn save_settings(Json(new_config): Json<crate::config::AgentConfig>) -> impl IntoResponse {
-    let mut config_path = crate::env::get_app_home();
-    config_path.push("config.json");
-
-    match crate::config::save_config(config_path, &new_config) {
-        Ok(_) => Json(serde_json::json!({"status": "ok"})).into_response(),
-        Err(e) => (axum::http::StatusCode::INTERNAL_SERVER_ERROR, e).into_response(),
-    }
-}
+// The `get_settings` / `save_settings` handlers were removed in #40. Reading the
+// agent config here served it straight from `load_config`, which overlays keychain
+// material onto the returned struct, and the write side accepted a whole config
+// from any caller. The app reads and writes config over Tauri IPC instead, so this
+// surface had no remaining consumer.
 
 /// Serves the single-page web dashboard HTML.
 async fn serve_dashboard_html() -> impl IntoResponse {
@@ -2241,21 +2241,6 @@ async fn serve_dashboard_html() -> impl IntoResponse {
     Html(html)
 }
 
-#[derive(Deserialize, Serialize)]
-struct EnrollRequest {
-    token: String,
-    public_key: String,
-    agent_id: String,
-}
-
-async fn mock_cloud_enroll(Json(payload): Json<EnrollRequest>) -> impl IntoResponse {
-    println!(
-        "[Mock Cloud] Received enrollment request! Agent: {} | Token: {}",
-        payload.agent_id, payload.token
-    );
-    Json(serde_json::json!({
-        "status": "success",
-        "message": "Agent enrolled successfully in B2B SaaS portal",
-        "agent_id": payload.agent_id,
-    }))
-}
+// `mock_cloud_enroll` and its `EnrollRequest` payload were removed in #40 — a stub
+// enrollment endpoint left on an unauthenticated port, superseded by the real
+// `enroll_agent` Tauri command.

--- a/daemon/src/env.rs
+++ b/daemon/src/env.rs
@@ -63,3 +63,52 @@ pub fn get_app_port(config: &AgentConfig) -> u16 {
 
     if is_dev() { 5006 } else { 5005 }
 }
+
+/// Whether the debug HTTP dashboard server may start (#40).
+///
+/// Off unless `TENBY10_DEBUG_HTTP` is set to a truthy value, so a normal run — and
+/// every installed app — opens no listening port. The server is a triage escape
+/// hatch only; the real dashboard renders in-app over Tauri IPC.
+pub fn debug_http_enabled() -> bool {
+    debug_http_enabled_from(env::var("TENBY10_DEBUG_HTTP").ok().as_deref())
+}
+
+/// Pure form of [`debug_http_enabled`], so the default-off behaviour is testable
+/// without mutating process environment from tests.
+fn debug_http_enabled_from(value: Option<&str>) -> bool {
+    match value {
+        Some(val) => {
+            let val = val.trim().to_ascii_lowercase();
+            // Treat an explicitly falsey value as off, so `TENBY10_DEBUG_HTTP=0`
+            // does what it looks like rather than enabling via mere presence.
+            !val.is_empty() && val != "0" && val != "false" && val != "no"
+        }
+        None => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_debug_http_is_off_unless_explicitly_enabled() {
+        // The default install must open no port (#40).
+        assert!(!debug_http_enabled_from(None), "unset -> off");
+        assert!(!debug_http_enabled_from(Some("")), "empty -> off");
+        assert!(!debug_http_enabled_from(Some("  ")), "whitespace -> off");
+
+        // An explicitly falsey value must mean off, not "present therefore on".
+        assert!(!debug_http_enabled_from(Some("0")), "0 -> off");
+        assert!(!debug_http_enabled_from(Some("false")), "false -> off");
+        assert!(!debug_http_enabled_from(Some("FALSE")), "case-insensitive");
+        assert!(!debug_http_enabled_from(Some("no")), "no -> off");
+    }
+
+    #[test]
+    fn test_debug_http_enables_on_a_truthy_value() {
+        assert!(debug_http_enabled_from(Some("1")));
+        assert!(debug_http_enabled_from(Some("true")));
+        assert!(debug_http_enabled_from(Some(" 1 ")), "trims whitespace");
+    }
+}

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -58,9 +58,20 @@ async fn main() {
     println!("Initializing Database at {:?}", db_path);
     let db = Arc::new(Database::new(db_path).expect("Failed to initialize SQLite database"));
 
-    // Start the local web dashboard server
-    let port = daemon::env::get_app_port(&config);
-    start_dashboard_server(db.clone(), port);
+    // Debug-only HTTP dashboard, off unless explicitly opted into (#40). The app's
+    // dashboard renders natively over IPC, so this exists purely as a triage escape
+    // hatch ("is it actually capturing?"). It stays off by default so a normal run
+    // opens no listening port.
+    if daemon::env::debug_http_enabled() {
+        let port = daemon::env::get_app_port(&config);
+        println!(
+            "[Dashboard] TENBY10_DEBUG_HTTP is set — starting the debug HTTP server on \
+             127.0.0.1:{}. It serves blurred screenshots and an activity CSV to anything \
+             that can reach loopback; unset the variable to disable it.",
+            port
+        );
+        start_dashboard_server(db.clone(), port);
+    }
 
     let state = Arc::new(TelemetryState::new());
 

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -394,12 +394,11 @@ pub fn run() {
     let db =
         Arc::new(daemon::db::Database::new(db_path).expect("Failed to initialize SQLite database"));
 
-    // Start local web server dashboard
-    let mut config_path = app_home.clone();
-    config_path.push("config.json");
-    let config = daemon::config::load_config(config_path).unwrap_or_default();
-    let port = daemon::env::get_app_port(&config);
-    daemon::dashboard::start_dashboard_server(db.clone(), port);
+    // No local HTTP server is started here (#40). The activity dashboard renders
+    // inside the app window from `#[tauri::command]` IPC, so the Axum server no
+    // longer backs any view — leaving it running would keep a loopback port open
+    // that nothing consumes. The standalone `daemon` binary can still opt into it
+    // for triage; see `daemon::dashboard::start_dashboard_server`.
 
     let state = Arc::new(daemon::daemon::TelemetryState::new());
 


### PR DESCRIPTION
## Summary
Retires the loopback HTTP dashboard server. Since the dashboard moved in-app (rendered from Tauri IPC), the Axum server backs no user-facing view — yet the installed app still started it at launch, keeping a port open that nothing consumes.

## Changes
- **Desktop app** — no longer starts the server. A default install now opens **no listening port**.
- **Standalone `daemon` binary** — keeps it as a triage escape hatch behind `TENBY10_DEBUG_HTTP`, **off by default**, with a startup line stating what it exposes while enabled.
- **Routes removed** — `/api/settings` (GET + POST) and `/api/enroll`. The read side returned the agent config straight from `load_config`, which overlays keychain material onto the struct it returns; the write side accepted a whole config from any caller; the enroll route was a leftover stub. All three are superseded by Tauri commands (`get_agent_config` / `save_agent_config` / `enroll_agent`).
- **`CorsLayer::permissive()` removed** — the dashboard HTML is same-origin and needed no cross-origin read access.
- **Docs** — README no longer presents the server as part of normal operation; AUDIT.md gains a verdict row for "the installed app opens no listening port".

## Verification
- `cargo fmt` / `clippy -D warnings` / `cargo test` green in both crates; daemon at **73 passing** (+2 new).
- `debug_http_enabled` is split around a pure helper so default-off is testable without mutating process env. Covered: unset, empty, whitespace, and explicitly falsey values (`0`, `false`, `FALSE`, `no`) all resolve to **off** — so the flag can't be enabled by mere presence.
- Confirmed structurally that the only remaining `start_dashboard_server` call sits inside the opt-in gate, the desktop reference is a comment, and no `api/settings`, `api/enroll`, or `CorsLayer` occurrences survive outside an explanatory comment.

Left in place deliberately: the read-only triage routes (`/`, `/api/data`, `/api/pending`, `/api/slot_details`, `/api/export`, `/screenshots`), which are the useful part of the escape hatch. Their doc comment now states plainly that while enabled the server is unauthenticated and readable by anything that can reach loopback.

closes #40
