### PR TITLE
bug: capture the macOS screen in memory instead of via screencapture

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -983,7 +983,7 @@ version = "0.1.0"
 dependencies = [
  "active-win-pos-rs",
  "axum",
- "base64 0.22.1",
+ "base64 0.23.0",
  "chrono",
  "core-foundation 0.10.1",
  "core-graphics 0.25.0",


### PR DESCRIPTION
## Summary
macOS screen capture has **never worked**. This is why re-granting Screen Recording, resetting TCC, and relaunching all changed nothing — the permission was never the problem.

(Supersedes #48, which I accidentally closed while trying to force GitHub to pick up a pushed commit; it could not be reopened. Same branch, same commits, plus a lockfile sync.)

## Root cause
`capture_raw_image()` shelled out to `screencapture -x -t png /dev/stdout` and collected it with `Command::output()`, which wires stdout to a **pipe**. `screencapture` requires a seekable destination and refuses a pipe, exiting having written nothing.

Verified on macOS 26.5.2 with Screen Recording granted:

| destination | result |
|---|---|
| regular file | exit 0, 1.5 MB, **3024x1964** |
| `/dev/stdout` via pipe | **0 bytes** — `cannot write file to intended destination` |

So it failed on every machine, always. The handler then reported *"Screen Recording permission is likely denied"*, which sent every diagnosis down the TCC rabbit hole.

It also explains the history: saved screenshots were all 800x600 because the old code fabricated a placeholder on this exact failure, and once that faking was removed, nothing was written at all.

## Fix
Capture via `CGDisplay::image()` (`CGDisplayCreateImage`), already available through the core-graphics 0.25 dependency:

- **No subprocess** — nothing left to fail on a pipe.
- **Raw bytes stay off disk.** A temp-file workaround would have written the raw, unblurred screenshot, breaking the AUDIT.md claim *"Raw screenshots never touch disk"*. In-process capture preserves it.
- **Walks `bytes_per_row`** instead of assuming a packed buffer, so rows don't shear on widths that aren't a multiple of the row alignment; converts BGRA -> RGBA.

## Verification
- Both on-device tests now **pass** — the same ones that failed before the fix.
- Captured image is **3024x1964**, matching what `screencapture`-to-file produces on this display.
- `fmt` / `clippy -D warnings` / `test` green in both crates (daemon 76 passing, 2 on-device ignored).
- No `Command::new` remains in `screen.rs`.

## Test hardening
The on-device test asserted only non-zero dimensions — which the 800x600 placeholder satisfied, so it would have passed throughout the entire period capture was broken. It now asserts the capture matches the real display and is explicitly not 800x600, written Retina-agnostically (`pixels_wide()` reports *points*, 1512x982 here, while the buffer is 2x pixels).

## Also included
One-line lockfile sync: `desktop/src-tauri/Cargo.lock` still recorded the daemon depending on base64 0.22.1 after #46 moved it to 0.23, leaving a dirty tree on any local build.

closes #47