### PR TITLE
fix: move the Gemini API key from the URL query string to a header

### DIFF
--- a/daemon/src/llm.rs
+++ b/daemon/src/llm.rs
@@ -129,7 +129,10 @@ impl LlmProvider for GeminiProvider {
 
         let res = self
             .client
-            .post(format!("https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key={}", self.api_key))
+            .post("https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent")
+            // The key rides a header, not the query string: URLs land in proxy
+            // and gateway logs.
+            .header("x-goog-api-key", &self.api_key)
             .json(&payload)
             .send()
             .map_err(|e| e.to_string())?;


### PR DESCRIPTION
## Summary

The Gemini provider in `daemon/src/llm.rs` sent the API key as a URL query parameter (`?key=...`). URLs routinely land in proxy and gateway logs, so as a matter of credential hygiene the key now rides the `x-goog-api-key` request header, which Google supports for exactly this. Endpoint, model, and payload are unchanged.

This also brings Gemini in line with the other two providers, which already pass their keys in headers.

Closes #135 (issue tracked in the cloud repo: pivotalpoint-io/tenby10-cloud#135)

## Changes

- Gemini requests post to the bare `:generateContent` endpoint and send the key via the `x-goog-api-key` header; the query string no longer carries it
- No other behavior change: same endpoint, same model, same payload
- Confirmed the OpenAI (`Authorization: Bearer`) and Anthropic (`x-api-key`) providers stay header-based — untouched

## Testing

- `cd daemon && cargo fmt -- --check`, `cargo clippy -- -D warnings`, `cargo test` — 82 tests pass
- Pre-commit hook additionally ran the desktop crate's fmt/clippy/tests — clean

## Overlap with #56

#56 (the pivotalpoint-io/tenby10-cloud#134 base-URL/model rework) makes this same change inside its larger diff; as noted there, whichever lands second is a one-hunk rebase. The header line and comment here match #56's wording to keep that rebase trivial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
