### PR TITLE
feat: configurable API base URL and model for the AI auditor

### DIFF
--- a/daemon/src/config.rs
+++ b/daemon/src/config.rs
@@ -45,6 +45,14 @@ pub struct AgentConfig {
     pub llm_provider: String,
     #[serde(default)]
     pub llm_api_key: String,
+    /// API base URL for the auditor provider. Empty = the provider's default
+    /// (see `llm::provider_defaults`). Set this to reach an OpenAI-compatible
+    /// gateway or a local Ollama (`http://localhost:11434/v1`).
+    #[serde(default)]
+    pub llm_base_url: String,
+    /// Model the auditor calls. Empty = the provider's default.
+    #[serde(default)]
+    pub llm_model: String,
     #[serde(default = "default_llm_prompt")]
     pub llm_prompt: String,
     #[serde(default)]
@@ -126,6 +134,8 @@ impl Default for AgentConfig {
             engine_mode: default_engine_mode(),
             llm_provider: String::new(),
             llm_api_key: String::new(),
+            llm_base_url: String::new(),
+            llm_model: String::new(),
             llm_prompt: default_llm_prompt(),
             dashboard_port: None,
             enforce_synthetic_detection: false,
@@ -311,6 +321,8 @@ pub fn generate_enrollment_keys(enrollment_token: &str) -> AgentConfig {
         engine_mode: default_engine_mode(),
         llm_provider: String::new(),
         llm_api_key: String::new(),
+        llm_base_url: String::new(),
+        llm_model: String::new(),
         llm_prompt: default_llm_prompt(),
         dashboard_port: None,
         enforce_synthetic_detection: false,

--- a/daemon/src/llm.rs
+++ b/daemon/src/llm.rs
@@ -2,6 +2,87 @@ use crate::config::AgentConfig;
 use reqwest::blocking::Client;
 use serde_json::Value;
 
+/// Per-provider defaults for `llm_base_url` / `llm_model`.
+///
+/// An empty config field means "use the default here". These are surfaced
+/// verbatim in the settings UI (as the placeholder of each field), so the
+/// endpoint and model the daemon will actually call are always visible —
+/// the UI never claims a model the daemon does not use.
+///
+/// Hardcoded model IDs rot: providers retire them. Both fields are
+/// user-editable precisely so a stale default is a one-line fix in Settings
+/// rather than a release.
+pub const OPENAI_DEFAULT_BASE_URL: &str = "https://api.openai.com/v1";
+pub const OPENAI_DEFAULT_MODEL: &str = "gpt-5-mini";
+pub const ANTHROPIC_DEFAULT_BASE_URL: &str = "https://api.anthropic.com/v1";
+pub const ANTHROPIC_DEFAULT_MODEL: &str = "claude-sonnet-5";
+pub const GEMINI_DEFAULT_BASE_URL: &str = "https://generativelanguage.googleapis.com/v1beta";
+pub const GEMINI_DEFAULT_MODEL: &str = "gemini-3.6-flash";
+
+/// `(default_base_url, default_model)` for a known provider.
+pub fn provider_defaults(provider: &str) -> Option<(&'static str, &'static str)> {
+    match provider.to_lowercase().as_str() {
+        "openai" => Some((OPENAI_DEFAULT_BASE_URL, OPENAI_DEFAULT_MODEL)),
+        "anthropic" => Some((ANTHROPIC_DEFAULT_BASE_URL, ANTHROPIC_DEFAULT_MODEL)),
+        "gemini" => Some((GEMINI_DEFAULT_BASE_URL, GEMINI_DEFAULT_MODEL)),
+        _ => None,
+    }
+}
+
+/// Join a base URL and a path without doubling or dropping the separator.
+fn join_url(base: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
+}
+
+/// Whether `raw` points at this machine. Loopback endpoints (Ollama, a local
+/// proxy) are the one case where plain `http://` is acceptable and where no
+/// API key is required.
+pub fn is_loopback_url(raw: &str) -> bool {
+    let Ok(url) = reqwest::Url::parse(raw) else {
+        return false;
+    };
+    match url.host_str() {
+        Some("localhost") => true,
+        Some(host) => host
+            .trim_start_matches('[')
+            .trim_end_matches(']')
+            .parse::<std::net::IpAddr>()
+            .map(|ip| ip.is_loopback())
+            .unwrap_or(false),
+        None => false,
+    }
+}
+
+/// Validate a user-supplied base URL.
+///
+/// The auditor request carries the API key **and** every window title in the
+/// slot, so a plaintext endpoint would put both on the wire in the clear. HTTP
+/// is therefore allowed only for loopback, where the traffic never leaves the
+/// machine. An empty string is valid and selects the provider default.
+pub fn validate_base_url(raw: &str) -> Result<(), String> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return Ok(());
+    }
+    let url = reqwest::Url::parse(raw).map_err(|_| {
+        "API base URL must be a full URL, e.g. https://api.example.com/v1".to_string()
+    })?;
+    match url.scheme() {
+        "https" => Ok(()),
+        "http" if is_loopback_url(raw) => Ok(()),
+        "http" => Err(
+            "API base URL must use https (http is allowed only for localhost). Your API key and \
+             window titles would otherwise travel unencrypted."
+                .to_string(),
+        ),
+        other => Err(format!("Unsupported URL scheme '{other}': use https")),
+    }
+}
+
 pub trait LlmProvider {
     fn evaluate_slot(
         &self,
@@ -12,6 +93,8 @@ pub trait LlmProvider {
 
 pub struct OpenAiProvider {
     api_key: String,
+    base_url: String,
+    model: String,
     client: Client,
 }
 
@@ -22,7 +105,7 @@ impl LlmProvider for OpenAiProvider {
         activity_text: &str,
     ) -> Result<(u32, String), String> {
         let payload = serde_json::json!({
-            "model": "gpt-4o-mini",
+            "model": self.model,
             "messages": [
                 { "role": "system", "content": system_prompt },
                 { "role": "user", "content": format!("Activity log:\n{}", activity_text) }
@@ -32,7 +115,7 @@ impl LlmProvider for OpenAiProvider {
 
         let res = self
             .client
-            .post("https://api.openai.com/v1/chat/completions")
+            .post(join_url(&self.base_url, "chat/completions"))
             .header("Authorization", format!("Bearer {}", self.api_key))
             .json(&payload)
             .send()
@@ -55,6 +138,8 @@ impl LlmProvider for OpenAiProvider {
 
 pub struct AnthropicProvider {
     api_key: String,
+    base_url: String,
+    model: String,
     client: Client,
 }
 
@@ -65,8 +150,13 @@ impl LlmProvider for AnthropicProvider {
         activity_text: &str,
     ) -> Result<(u32, String), String> {
         let payload = serde_json::json!({
-            "model": "claude-3-5-sonnet-20240620",
-            "max_tokens": 512,
+            "model": self.model,
+            // Current Claude models think by default, and `max_tokens` caps
+            // thinking *plus* the reply. The auditor's own output is a small
+            // JSON object, but a tight cap would truncate it mid-object once
+            // thinking is counted — so leave headroom. Unused budget is not
+            // billed.
+            "max_tokens": 4096,
             "system": system_prompt,
             "messages": [
                 { "role": "user", "content": format!("Activity log:\n{}", activity_text) }
@@ -75,7 +165,7 @@ impl LlmProvider for AnthropicProvider {
 
         let res = self
             .client
-            .post("https://api.anthropic.com/v1/messages")
+            .post(join_url(&self.base_url, "messages"))
             .header("x-api-key", &self.api_key)
             .header("anthropic-version", "2023-06-01")
             .json(&payload)
@@ -84,7 +174,20 @@ impl LlmProvider for AnthropicProvider {
 
         let json = res.json::<Value>().map_err(|e| e.to_string())?;
 
-        if let Some(content) = json["content"][0]["text"].as_str() {
+        // Thinking-capable models put `thinking` blocks before the text block,
+        // so take the first block that actually carries text rather than
+        // assuming index 0.
+        let text = json["content"]
+            .as_array()
+            .and_then(|blocks| {
+                blocks
+                    .iter()
+                    .find(|b| b["type"] == "text")
+                    .and_then(|b| b["text"].as_str())
+            })
+            .or_else(|| json["content"][0]["text"].as_str());
+
+        if let Some(content) = text {
             let clean_content = content
                 .trim()
                 .strip_prefix("```json")
@@ -106,6 +209,8 @@ impl LlmProvider for AnthropicProvider {
 
 pub struct GeminiProvider {
     api_key: String,
+    base_url: String,
+    model: String,
     client: Client,
 }
 
@@ -127,9 +232,14 @@ impl LlmProvider for GeminiProvider {
             }
         });
 
+        let url = join_url(
+            &self.base_url,
+            &format!("models/{}:generateContent", self.model),
+        );
+
         let res = self
             .client
-            .post("https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent")
+            .post(url)
             // The key rides a header, not the query string: URLs land in proxy
             // and gateway logs.
             .header("x-goog-api-key", &self.api_key)
@@ -153,17 +263,58 @@ impl LlmProvider for GeminiProvider {
 }
 
 pub fn get_llm_provider(config: &AgentConfig) -> Option<Box<dyn LlmProvider>> {
-    if config.llm_api_key.is_empty() || config.llm_provider.is_empty() {
+    if config.llm_provider.is_empty() {
         return None;
     }
+
+    let (default_base_url, default_model) = provider_defaults(&config.llm_provider)?;
+
+    let base_url = if config.llm_base_url.trim().is_empty() {
+        default_base_url.to_string()
+    } else {
+        config.llm_base_url.trim().to_string()
+    };
+
+    if let Err(e) = validate_base_url(&base_url) {
+        eprintln!("[LLM] Invalid API base URL, auditor disabled: {e}");
+        return None;
+    }
+
+    // A local endpoint (Ollama, a local proxy) authenticates by not being
+    // reachable from anywhere else, so an empty key is legitimate there. Every
+    // remote endpoint still requires one.
+    if config.llm_api_key.is_empty() && !is_loopback_url(&base_url) {
+        return None;
+    }
+
+    let model = if config.llm_model.trim().is_empty() {
+        default_model.to_string()
+    } else {
+        config.llm_model.trim().to_string()
+    };
 
     let client = Client::new();
     let api_key = config.llm_api_key.clone();
 
     match config.llm_provider.to_lowercase().as_str() {
-        "openai" => Some(Box::new(OpenAiProvider { api_key, client })),
-        "gemini" => Some(Box::new(GeminiProvider { api_key, client })),
-        "anthropic" => Some(Box::new(AnthropicProvider { api_key, client })),
+        "openai" => Some(Box::new(OpenAiProvider {
+            api_key,
+            base_url,
+            model,
+            client,
+        })),
+        "gemini" => Some(Box::new(GeminiProvider {
+            api_key,
+            base_url,
+            model,
+            client,
+        })),
+        "anthropic" => Some(Box::new(AnthropicProvider {
+            api_key,
+            base_url,
+            model,
+            client,
+        })),
         _ => None,
     }
 }
@@ -206,5 +357,80 @@ mod tests {
 
         config.llm_provider = "unknown".to_string();
         assert!(get_llm_provider(&config).is_none());
+    }
+
+    #[test]
+    fn test_join_url_handles_slashes() {
+        assert_eq!(
+            join_url("https://api.example.com/v1", "messages"),
+            "https://api.example.com/v1/messages"
+        );
+        // A trailing slash pasted from a browser must not double up.
+        assert_eq!(
+            join_url("https://api.example.com/v1/", "messages"),
+            "https://api.example.com/v1/messages"
+        );
+        assert_eq!(
+            join_url("https://api.example.com/v1/", "/messages"),
+            "https://api.example.com/v1/messages"
+        );
+    }
+
+    #[test]
+    fn test_validate_base_url() {
+        // Empty selects the provider default.
+        assert!(validate_base_url("").is_ok());
+        assert!(validate_base_url("https://api.openai.com/v1").is_ok());
+
+        // Loopback may use plain http — the traffic never leaves the machine.
+        assert!(validate_base_url("http://localhost:11434/v1").is_ok());
+        assert!(validate_base_url("http://127.0.0.1:11434/v1").is_ok());
+        assert!(validate_base_url("http://[::1]:11434/v1").is_ok());
+
+        // Remote http would put the API key and window titles in the clear.
+        assert!(validate_base_url("http://api.example.com/v1").is_err());
+        assert!(validate_base_url("ftp://api.example.com").is_err());
+        assert!(validate_base_url("not a url").is_err());
+    }
+
+    #[test]
+    fn test_is_loopback_url() {
+        assert!(is_loopback_url("http://localhost:11434/v1"));
+        assert!(is_loopback_url("http://127.0.0.1:11434"));
+        assert!(is_loopback_url("http://127.1.2.3:11434"));
+        assert!(is_loopback_url("http://[::1]:11434"));
+        assert!(!is_loopback_url("https://api.openai.com/v1"));
+        // Not loopback despite the prefix — a real remote host.
+        assert!(!is_loopback_url("https://localhost.example.com/v1"));
+    }
+
+    #[test]
+    fn test_local_endpoint_needs_no_api_key() {
+        let mut config = AgentConfig::default();
+        config.llm_provider = "openai".to_string();
+        config.llm_base_url = "http://localhost:11434/v1".to_string();
+        config.llm_model = "llama3.1".to_string();
+        // Ollama ignores the key; requiring one would block the local path.
+        assert!(config.llm_api_key.is_empty());
+        assert!(get_llm_provider(&config).is_some());
+    }
+
+    #[test]
+    fn test_remote_http_base_url_is_rejected() {
+        let mut config = AgentConfig::default();
+        config.llm_provider = "openai".to_string();
+        config.llm_api_key = "test_key".to_string();
+        config.llm_base_url = "http://api.example.com/v1".to_string();
+        assert!(get_llm_provider(&config).is_none());
+    }
+
+    #[test]
+    fn test_provider_defaults_are_valid_https_urls() {
+        for provider in ["openai", "anthropic", "gemini"] {
+            let (base_url, model) = provider_defaults(provider).expect("known provider");
+            assert!(validate_base_url(base_url).is_ok(), "{provider} base url");
+            assert!(!model.is_empty(), "{provider} model");
+        }
+        assert!(provider_defaults("unknown").is_none());
     }
 }

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -278,6 +278,30 @@ async fn get_agent_config() -> Result<daemon::config::AgentConfig, String> {
     daemon::config::load_config(config_path)
 }
 
+/// The endpoint and model each provider actually calls when the user leaves
+/// those settings blank. The UI reads them from here rather than carrying its
+/// own copy, so the form can never advertise a model the daemon doesn't use.
+#[derive(serde::Serialize)]
+struct LlmProviderDefaults {
+    provider: String,
+    base_url: String,
+    model: String,
+}
+
+#[tauri::command]
+async fn get_llm_provider_defaults() -> Result<Vec<LlmProviderDefaults>, String> {
+    Ok(["openai", "anthropic", "gemini"]
+        .iter()
+        .filter_map(|provider| {
+            daemon::llm::provider_defaults(provider).map(|(base_url, model)| LlmProviderDefaults {
+                provider: provider.to_string(),
+                base_url: base_url.to_string(),
+                model: model.to_string(),
+            })
+        })
+        .collect())
+}
+
 #[tauri::command]
 async fn save_agent_config(new_config: daemon::config::AgentConfig) -> Result<(), String> {
     let app_home = daemon::env::get_app_home();
@@ -418,6 +442,7 @@ pub fn run() {
             export_dashboard_csv,
             get_agent_config,
             save_agent_config,
+            get_llm_provider_defaults,
             check_permissions,
             get_capture_health,
             open_accessibility_settings,

--- a/desktop/src/index.html
+++ b/desktop/src/index.html
@@ -142,15 +142,28 @@
             <div class="form-group">
               <label class="input-label" for="ai-provider">LLM Provider</label>
               <select id="ai-provider">
-                <option value="openai">OpenAI (GPT-4o)</option>
-                <option value="anthropic">Anthropic (Claude 3.5 Sonnet)</option>
+                <option value="openai">OpenAI</option>
+                <option value="anthropic">Anthropic (Claude)</option>
                 <option value="gemini">Google Gemini</option>
               </select>
             </div>
 
             <div class="form-group">
+              <label class="input-label" for="ai-model">Model</label>
+              <input id="ai-model" type="text" spellcheck="false" autocomplete="off" />
+              <p id="ai-model-hint" class="desc"></p>
+            </div>
+
+            <div class="form-group">
+              <label class="input-label" for="ai-base-url">API Base URL</label>
+              <input id="ai-base-url" type="text" spellcheck="false" autocomplete="off" />
+              <p id="ai-base-url-hint" class="desc"></p>
+            </div>
+
+            <div class="form-group">
               <label class="input-label" for="ai-api-key">API Key</label>
               <input id="ai-api-key" type="password" placeholder="sk-... or API Key" autocomplete="off" />
+              <p id="ai-api-key-hint" class="desc"></p>
             </div>
 
             <div class="form-group">

--- a/desktop/src/main.js
+++ b/desktop/src/main.js
@@ -178,6 +178,100 @@ if (aiApiKeyInput) {
   });
 }
 
+// Per-provider endpoint/model defaults, read from the daemon (see llm.rs) so
+// this form always shows what the auditor will actually call.
+let llmProviderDefaults = {};
+
+async function loadLlmProviderDefaults() {
+  try {
+    const rows = await invoke("get_llm_provider_defaults");
+    llmProviderDefaults = Object.fromEntries(
+      rows.map(r => [r.provider, { baseUrl: r.base_url, model: r.model }])
+    );
+  } catch (err) {
+    console.error("Failed to load LLM provider defaults:", err);
+    llmProviderDefaults = {};
+  }
+}
+
+// A local endpoint's traffic never leaves the machine, so it may use plain
+// http and needs no API key. Mirrors is_loopback_url() in llm.rs.
+function isLoopbackUrl(raw) {
+  try {
+    const host = new URL(raw).hostname.replace(/^\[|\]$/g, "");
+    return host === "localhost" || host === "::1" || /^127\./.test(host);
+  } catch {
+    return false;
+  }
+}
+
+// Mirrors validate_base_url() in llm.rs. Returns an error string, or null.
+function validateBaseUrl(raw) {
+  const value = raw.trim();
+  if (!value) return null; // empty = use the provider default
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    return "⚠️ API Base URL must be a full URL, e.g. https://api.example.com/v1";
+  }
+  if (url.protocol === "https:") return null;
+  if (url.protocol === "http:" && isLoopbackUrl(value)) return null;
+  if (url.protocol === "http:") {
+    return "⚠️ API Base URL must use https (http is allowed only for localhost). " +
+      "Your API key and window titles would otherwise travel unencrypted.";
+  }
+  return `⚠️ Unsupported URL scheme '${url.protocol.replace(":", "")}': use https`;
+}
+
+// Show each field's effective value as its placeholder, so a blank field is
+// never ambiguous about what the daemon will use.
+function updateLlmProviderHints() {
+  const provider = document.getElementById("ai-provider").value;
+  const defaults = llmProviderDefaults[provider];
+  const modelInput = document.getElementById("ai-model");
+  const baseUrlInput = document.getElementById("ai-base-url");
+  const modelHint = document.getElementById("ai-model-hint");
+  const baseUrlHint = document.getElementById("ai-base-url-hint");
+  const apiKeyHint = document.getElementById("ai-api-key-hint");
+
+  if (modelInput) modelInput.placeholder = defaults ? defaults.model : "";
+  if (baseUrlInput) baseUrlInput.placeholder = defaults ? defaults.baseUrl : "";
+  if (modelHint) {
+    modelHint.innerText = defaults
+      ? `Leave blank to use ${defaults.model}.`
+      : "";
+  }
+  if (baseUrlHint) {
+    baseUrlHint.innerText = defaults
+      ? `Leave blank to use ${defaults.baseUrl}. Point this at a company gateway, ` +
+        "or at a local model (Ollama: http://localhost:11434/v1 with the OpenAI provider)."
+      : "";
+  }
+  if (apiKeyHint) {
+    const local = baseUrlInput && isLoopbackUrl(baseUrlInput.value.trim());
+    apiKeyHint.innerText = local
+      ? "Not required for a local endpoint."
+      : "Stored in your OS keychain, never in a file and never sent to tenby10.";
+  }
+}
+
+const aiProviderSelect = document.getElementById("ai-provider");
+if (aiProviderSelect) {
+  aiProviderSelect.addEventListener("change", updateLlmProviderHints);
+}
+
+const aiBaseUrlInput = document.getElementById("ai-base-url");
+if (aiBaseUrlInput) {
+  aiBaseUrlInput.addEventListener("input", () => {
+    updateLlmProviderHints();
+    const errorEl = document.getElementById("validation-error");
+    if (errorEl) {
+      errorEl.style.display = "none";
+    }
+  });
+}
+
 function updateTokenEstimate() {
   const promptText = document.getElementById("ai-prompt").value;
   const wordCount = promptText.trim().split(/\s+/).filter(w => w.length > 0).length;
@@ -222,6 +316,10 @@ async function loadAgentConfig() {
     }
     document.getElementById("ai-provider").value = currentConfig.llm_provider || "openai";
     document.getElementById("ai-api-key").value = currentConfig.llm_api_key || "";
+    document.getElementById("ai-model").value = currentConfig.llm_model || "";
+    document.getElementById("ai-base-url").value = currentConfig.llm_base_url || "";
+    await loadLlmProviderDefaults();
+    updateLlmProviderHints();
     document.getElementById("ai-prompt").value = currentConfig.llm_prompt || "";
 
     updateTokenEstimate();
@@ -309,23 +407,31 @@ if (saveSettingsBtn) {
       const isLlmEnabled = (aiEngineToggle && aiEngineToggle.checked);
       const apiKey = document.getElementById("ai-api-key").value.trim();
       const prompt = document.getElementById("ai-prompt").value.trim();
+      const baseUrl = document.getElementById("ai-base-url").value.trim();
+      const model = document.getElementById("ai-model").value.trim();
+
+      const rejectSave = (message) => {
+        if (errorEl) {
+          errorEl.innerText = message;
+          errorEl.style.display = "block";
+        }
+        saveSettingsBtn.disabled = false;
+        saveSettingsBtn.innerText = "Save Settings";
+      };
+
       if (isLlmEnabled) {
-        if (!apiKey) {
-          if (errorEl) {
-            errorEl.innerText = "⚠️ API Key is required when AI Auditor is enabled.";
-            errorEl.style.display = "block";
-          }
-          saveSettingsBtn.disabled = false;
-          saveSettingsBtn.innerText = "Save Settings";
+        const baseUrlError = validateBaseUrl(baseUrl);
+        if (baseUrlError) {
+          rejectSave(baseUrlError);
+          return;
+        }
+        // A local endpoint needs no key (Ollama ignores it); every remote one does.
+        if (!apiKey && !isLoopbackUrl(baseUrl)) {
+          rejectSave("⚠️ API Key is required when AI Auditor is enabled.");
           return;
         }
         if (!prompt) {
-          if (errorEl) {
-            errorEl.innerText = "⚠️ System Auditor Prompt is required when AI Auditor is enabled.";
-            errorEl.style.display = "block";
-          }
-          saveSettingsBtn.disabled = false;
-          saveSettingsBtn.innerText = "Save Settings";
+          rejectSave("⚠️ System Auditor Prompt is required when AI Auditor is enabled.");
           return;
         }
       }
@@ -333,6 +439,8 @@ if (saveSettingsBtn) {
       config.engine_mode = isLlmEnabled ? "llm" : "static";
       config.llm_provider = document.getElementById("ai-provider").value;
       config.llm_api_key = apiKey;
+      config.llm_base_url = baseUrl;
+      config.llm_model = model;
       config.llm_prompt = prompt;
 
       await invoke("save_agent_config", { newConfig: config });


### PR DESCRIPTION
Replaces #56, which GitHub marked merged when its base branch (`feat/130-remove-screenshot-subsystem`) was deleted after #55 landed — but the content never reached `main`. Same commit, now rebased onto `main` and targeting it directly, so this one also gets real CI (#56 only ever ran PR-Lint, because `ci.yml` triggers on `pull_request: branches: [main]` only).

## Summary

The auditor's endpoint and model are hardcoded per provider, and **two of the three hardcoded models on `main` today are no longer served**: `claude-3-5-sonnet-20240620` was retired 2025-10-28 and `gemini-1.5-flash` returns 404 now that Gemini 1.5 is shut down. LLM mode is broken for two of three providers, with no user-side fix short of a release. `gpt-4o-mini` still answers but is on the retirement path.

Model IDs rot. The config has to be able to outlive them.

## What changes

Two new settings, both empty-by-default (empty = use the provider default):

- **`llm_base_url`** — point the auditor at an OpenAI-compatible gateway, or at a local model. This is also the Ollama support ADR 0005 promised but never shipped: OpenAI provider + `http://localhost:11434/v1`.
- **`llm_model`** — pick the model, so a retired default becomes a one-line fix in Settings instead of a release.

Defaults refreshed to `claude-sonnet-5` / `gemini-3.6-flash` / `gpt-5-mini`.

## Keeping the UI honest

The provider dropdown said "OpenAI (GPT-4o)" while the code called `gpt-4o-mini`. Now:

- The dropdown names the provider only; the model lives in exactly one place.
- The form fetches defaults from the daemon over IPC (`get_llm_provider_defaults` → `llm::provider_defaults`) rather than carrying a second copy that can drift.
- Each field shows its effective value as placeholder + hint, so a blank field is never ambiguous about what will be called.

## Safety properties

Enforced in the daemon, mirrored in the form so the error arrives before saving:

- **https required, except loopback.** The auditor request carries the API key *and* every window title in the slot; a plaintext remote endpoint would put both on the wire in the clear.
- **A loopback endpoint needs no API key** (Ollama ignores it), so the local path is reachable. Every remote endpoint still requires one.

## Relationship to #57

#57 moved the Gemini key from the URL query string to the `x-goog-api-key` header. This branch rewrote the same provider layer and already contains that change — it survives here exactly once, verified after the rebase. No behaviour from #57 is lost.

Also: **Anthropic `max_tokens` 512 → 4096.** Current Claude models think by default and `max_tokens` caps thinking *plus* reply, so the old cap would truncate the auditor's JSON mid-object. Response parsing now finds the first `text` block instead of assuming index 0, for the same reason.

## Verification

- 88 daemon tests pass, with new coverage for URL joining, base-URL validation, loopback detection, the no-key local path, and rejection of remote plaintext.
- `cargo fmt` / `cargo clippy -D warnings` / `cargo test` green on both crates after the rebase.
- Settings page driven end to end in a browser against a stubbed IPC layer: defaults populate per provider, switching provider updates both placeholders, remote `http://` and malformed URLs are refused with the right message, a local endpoint saves with an empty key, and an https gateway with a custom model round-trips into the saved config.

## Not in scope

`llm_model` arguably belongs in `EffectiveConfig` — which model scored a slot is part of the rubric a verifier should see (policy authenticity, cloud #17). That needs an `EFFECTIVE_CONFIG_SCHEME` bump plus cloud-side handling.

Issue: pivotalpoint-io/tenby10-cloud#134

closes #134