### PR TITLE
feat: show the daily work note in the dashboard

### DIFF
--- a/daemon/src/db.rs
+++ b/daemon/src/db.rs
@@ -100,6 +100,7 @@ pub struct SignedSlot {
 /// Rows are append-only: a correction is a new `revision` for the same `period_start`,
 /// never an edit. `withdrawn` is a sharing decision, not a claim about the past, so it
 /// is deliberately outside the signed payload.
+#[derive(serde::Serialize, serde::Deserialize)]
 pub struct WorkSummary {
     pub id: i64,
     pub period_start: i64,

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -221,6 +221,33 @@ async fn dashboard_pending_slots(
         .map_err(|e| format!("Database error: {}", e))
 }
 
+/// The daily work notes (ADR 0019) covering `[from, to)`, latest revision per day,
+/// withdrawn days omitted. Empty when the user has no AI configured — the dashboard
+/// renders that as an invitation rather than an error.
+#[tauri::command]
+async fn dashboard_work_notes(
+    db: tauri::State<'_, Arc<daemon::db::Database>>,
+    from: i64,
+    to: i64,
+) -> Result<Vec<daemon::db::WorkSummary>, String> {
+    let db_clone = db.inner().clone();
+    tokio::task::spawn_blocking(move || db_clone.get_work_summaries(from, to))
+        .await
+        .map_err(|e| format!("Task join error: {}", e))?
+        .map_err(|e| format!("Database error: {}", e))
+}
+
+/// Whether note generation is live right now: the user's own AI is configured and
+/// notes are not opted out. Drives the dashboard's empty state, so the invitation
+/// only appears to people who would actually gain something by acting on it.
+#[tauri::command]
+async fn work_notes_enabled() -> Result<bool, String> {
+    let mut config_path = daemon::env::get_app_home();
+    config_path.push("config.json");
+    let config = daemon::config::load_config(config_path).unwrap_or_default();
+    Ok(!config.disable_work_summaries && daemon::llm::get_llm_provider(&config).is_some())
+}
+
 /// Classified minute-by-minute activity for a single 10-minute slot.
 #[tauri::command]
 async fn dashboard_slot_details(
@@ -439,6 +466,8 @@ pub fn run() {
             dashboard_slots,
             dashboard_pending_slots,
             dashboard_slot_details,
+            dashboard_work_notes,
+            work_notes_enabled,
             export_dashboard_csv,
             get_agent_config,
             save_agent_config,

--- a/desktop/src/dashboard.css
+++ b/desktop/src/dashboard.css
@@ -849,3 +849,71 @@
             color: var(--text-muted);
             padding-bottom: 0.5rem;
         }
+
+        /* Daily work note (ADR 0019). The plain-words answer to "what was worked
+           on", shown above the timeline because that is the question people bring
+           to a day. Same text a client would read, so it is styled to be read,
+           not scanned. */
+        .work-note-card {
+            background: rgba(16, 185, 129, 0.06);
+            border: 1px solid rgba(16, 185, 129, 0.18);
+            border-radius: 12px;
+            padding: 1.2rem 1.4rem;
+            margin-bottom: 2rem;
+        }
+
+        .work-note-label {
+            font-size: 0.8rem;
+            text-transform: uppercase;
+            color: var(--text-muted);
+            letter-spacing: 0.8px;
+            margin-bottom: 0.7rem;
+        }
+
+        .work-note-text {
+            font-size: 1rem;
+            line-height: 1.6;
+            color: var(--text-primary, #e5e7eb);
+            margin: 0;
+        }
+
+        .work-note-meta {
+            display: block;
+            margin-top: 0.7rem;
+            font-size: 0.72rem;
+            color: var(--text-muted);
+        }
+
+        /* No AI configured: an invitation, not a warning. Nothing is broken. */
+        .work-note-empty {
+            background: rgba(255, 255, 255, 0.03);
+            border-color: var(--border-card);
+        }
+
+        .work-note-empty .work-note-text {
+            font-size: 0.9rem;
+            color: var(--text-muted);
+        }
+
+        .work-note-row {
+            display: flex;
+            gap: 1rem;
+            align-items: baseline;
+            padding: 0.6rem 0;
+            border-top: 1px solid var(--border-card);
+        }
+
+        .work-note-row:first-of-type {
+            border-top: none;
+        }
+
+        .work-note-day {
+            flex: 0 0 4.5rem;
+            font-size: 0.78rem;
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .work-note-row .work-note-text {
+            font-size: 0.92rem;
+        }

--- a/desktop/src/dashboard.js
+++ b/desktop/src/dashboard.js
@@ -26,11 +26,71 @@ function goHome() {
         let currentViewMode = 'daily';
         let weekStartDay = parseInt(localStorage.getItem('weekStartDay') || '1', 10); // 1 = Monday, 0 = Sunday
 
+        // Daily work notes (ADR 0019), keyed by YYYY-MM-DD, plus whether note
+        // generation is live at all. Empty is a normal state, not an error: without
+        // an AI configured the log still shows hours, categories and rules.
+        let workNotes = {};
+        let workNotesEnabled = false;
+
+        function dateKeyOf(unixSeconds) {
+            const d = new Date(unixSeconds * 1000);
+            const y = d.getFullYear();
+            const m = String(d.getMonth() + 1).padStart(2, '0');
+            const day = String(d.getDate()).padStart(2, '0');
+            return `${y}-${m}-${day}`;
+        }
+
+        async function fetchWorkNotes() {
+            try {
+                workNotesEnabled = await invoke('work_notes_enabled');
+                // One fetch covers every view; the volume is one row per worked day.
+                const notes = await invoke('dashboard_work_notes', { from: 0, to: 4102444800 });
+                workNotes = {};
+                (notes || []).forEach(note => {
+                    workNotes[dateKeyOf(note.period_start)] = note;
+                });
+            } catch (err) {
+                console.error('Error fetching work notes', err);
+            }
+        }
+
+        /// The note card shown above a day's timeline. Returns '' when there is
+        /// nothing honest to show — no note and no reason to nag.
+        function renderWorkNote(dateKey) {
+            const note = workNotes[dateKey];
+            if (note) {
+                const generated = new Date(note.generated_at * 1000);
+                const dayEnd = note.period_end;
+                // Contemporaneity is the point, so lateness is stated, never hidden.
+                const late = note.generated_at - dayEnd > 48 * 3600;
+                const revised = note.revision > 0 ? ' · revised' : '';
+                return `
+                    <div class="work-note-card">
+                        <h4 class="work-note-label">What was worked on</h4>
+                        <p class="work-note-text">${escapeHtml(note.summary_text)}</p>
+                        <span class="work-note-meta">
+                            Written by your AI from the work log on ${generated.toLocaleDateString()}${revised}${late ? ' · written late' : ''}
+                        </span>
+                    </div>
+                `;
+            }
+            if (!workNotesEnabled) {
+                return `
+                    <div class="work-note-card work-note-empty">
+                        <p class="work-note-text">Connect your own AI in Settings and tenby10 writes a short note of each day's work, in plain words.</p>
+                        <span class="work-note-meta">Without it, your log shows hours and categories only.</span>
+                    </div>
+                `;
+            }
+            return '';
+        }
+
         // Fetch dashboard data
         async function fetchDashboardData() {
             try {
                 const slots = await invoke('dashboard_slots');
                 const pendingSlots = await invoke('dashboard_pending_slots');
+                await fetchWorkNotes();
 
                 globalSlots = slots || [];
 
@@ -640,6 +700,8 @@ function goHome() {
                     </div>
                 </div>
 
+                ${renderWorkNote(currentDateKey)}
+
                 <div style="margin-bottom: 2rem; background: rgba(0,0,0,0.15); border: 1px solid var(--border-card); border-radius: 12px; padding: 1.2rem;">
                     <h4 style="font-size: 0.8rem; text-transform: uppercase; color: var(--text-muted); letter-spacing: 0.8px; margin-bottom: 0.6rem;">24-Hour Focus Heatmap</h4>
                     <div class="heatmap-bar">
@@ -678,6 +740,34 @@ function goHome() {
             return startOfWeek;
         }
 
+        /// The week's notes, stacked oldest first. This is the "what shipped this week"
+        /// read — the same text a client would see, before anyone sends it.
+        function renderWeekNotes(startOfWeek) {
+            const rows = [];
+            for (let i = 0; i < 7; i++) {
+                const cur = new Date(startOfWeek);
+                cur.setDate(cur.getDate() + i);
+                const y = cur.getFullYear();
+                const m = String(cur.getMonth() + 1).padStart(2, '0');
+                const d = String(cur.getDate()).padStart(2, '0');
+                const note = workNotes[`${y}-${m}-${d}`];
+                if (!note) continue;
+                rows.push(`
+                    <div class="work-note-row">
+                        <span class="work-note-day">${cur.toLocaleDateString('en-US', { weekday: 'short', day: 'numeric' })}</span>
+                        <p class="work-note-text">${escapeHtml(note.summary_text)}</p>
+                    </div>
+                `);
+            }
+            if (rows.length === 0) return '';
+            return `
+                <div class="work-note-card">
+                    <h4 class="work-note-label">What was worked on this week</h4>
+                    ${rows.join('')}
+                </div>
+            `;
+        }
+
         function renderWeeklyView() {
             const container = document.getElementById('week-view-container');
             
@@ -707,6 +797,7 @@ function goHome() {
                         <span class="day-view-meta">Weekly aggregate productivity overview.</span>
                     </div>
                 </div>
+                ${renderWeekNotes(startOfWeek)}
                 <div class="month-grid" style="margin-top: 0;">
             `;
 

--- a/desktop/src/index.html
+++ b/desktop/src/index.html
@@ -172,6 +172,28 @@
               <p id="token-estimate" class="token-estimate-text"></p>
             </div>
 
+            <!-- Daily work notes (ADR 0019). On because the AI is on; the switch is
+                 here for the exception case, not as a setup step. -->
+            <div class="ai-toggle-header" style="margin-top: 0.5rem;">
+              <label class="input-label" for="summary-toggle" style="margin: 0;">Daily work notes</label>
+              <label class="switch">
+                <input id="summary-toggle" type="checkbox" checked />
+                <span class="slider round"></span>
+              </label>
+            </div>
+            <p class="desc">
+              Once a day is over, your AI writes a short note of what was worked on, from
+              your billable time. It appears in your log, and on any link you share.
+            </p>
+
+            <div class="form-group" id="summary-prompt-group">
+              <label class="input-label" for="summary-prompt">Work Note Prompt</label>
+              <textarea id="summary-prompt" style="height: 120px;"></textarea>
+              <p class="desc">
+                These rules travel with every note, so a reader can always see what wrote it.
+              </p>
+            </div>
+
             <p class="desc" style="margin-top: 0.75rem;">
               The auditor receives text only: application names, window titles and
               input counts for each minute of the slot. tenby10 never captures your

--- a/desktop/src/main.js
+++ b/desktop/src/main.js
@@ -322,6 +322,17 @@ async function loadAgentConfig() {
     updateLlmProviderHints();
     document.getElementById("ai-prompt").value = currentConfig.llm_prompt || "";
 
+    // Work notes are on unless explicitly turned off (ADR 0019): the config stores
+    // the opt-out, the switch shows the state.
+    const summaryToggle = document.getElementById("summary-toggle");
+    if (summaryToggle) {
+      summaryToggle.checked = !currentConfig.disable_work_summaries;
+    }
+    const summaryPrompt = document.getElementById("summary-prompt");
+    if (summaryPrompt) {
+      summaryPrompt.value = currentConfig.summary_prompt || "";
+    }
+
     updateTokenEstimate();
     toggleLlmFields(isLlm);
   } catch (err) {
@@ -436,7 +447,21 @@ if (saveSettingsBtn) {
         }
       }
 
+      const summaryToggleEl = document.getElementById("summary-toggle");
+      const summaryPromptEl = document.getElementById("summary-prompt");
+      if (isLlmEnabled && summaryToggleEl && summaryToggleEl.checked) {
+        // A note with no rules behind it is exactly what we refuse to produce.
+        if (summaryPromptEl && !summaryPromptEl.value.trim()) {
+          rejectSave("⚠️ Work Note Prompt is required while daily work notes are on.");
+          return;
+        }
+      }
+
       config.engine_mode = isLlmEnabled ? "llm" : "static";
+      config.disable_work_summaries = !(summaryToggleEl && summaryToggleEl.checked);
+      if (summaryPromptEl) {
+        config.summary_prompt = summaryPromptEl.value.trim();
+      }
       config.llm_provider = document.getElementById("ai-provider").value;
       config.llm_api_key = apiKey;
       config.llm_base_url = baseUrl;


### PR DESCRIPTION
## Summary

Closes #65. UI slice of #60 (ADR 0019). The note was written and signed by the previous slice but nothing rendered it, so the feature was invisible to the person it is for.

## Changes

- **Daily view** opens with the note, above the timeline: "what was worked on", in the plain words the AI wrote from that day's billable time. That is the question people bring to a day's log, and it is the same text a client will eventually read — so the worker sees it first, on their own screen, before anyone else does.
- **Weekly view** stacks the week's notes. That is the weekly-visibility read the positioning rests on, available to the worker now rather than after the cloud slice.
- **Settings (AI tab)** gains the work-note prompt and the opt-out switch, beside the scoring prompt they mirror. Saving with notes on and an empty prompt is refused: a note with no rules behind it is exactly what this design refuses to produce.
- Two commands back it: `dashboard_work_notes(from, to)` and `work_notes_enabled()`.

## Honesty in the UI

Written-on dates are always shown, and a note generated more than 48h after its day is labelled late — contemporaneity is the value of the record, so lateness is stated rather than hidden. Revisions are labelled too.

Three states, deliberately different:
- **Note exists** → the card.
- **No AI configured** → an invitation in its place, and only on days that have activity. Not a warning: without AI the log still shows hours, categories and rules, and nothing is broken.
- **AI on, note not written yet** → nothing at all. An empty space is honest; a placeholder would be noise.

## Verification

Rendered the real `dashboard.js`/`.css` against fixture data in a browser and checked all three states plus the weekly stack. Screenshots in the thread below. Rust and JS both build; full daemon suite green.