### PR TITLE
feat: sync work notes to the cloud after a correction window

### DIFF
--- a/daemon/src/daemon.rs
+++ b/daemon/src/daemon.rs
@@ -879,6 +879,18 @@ pub fn aggregate_slot(db: &Database, config: &crate::config::AgentConfig, slot_s
             Ok(_) => {}
             Err(e) => eprintln!("[Sync] {e}"),
         }
+
+        // Work notes ride the same beat but their own chain, so a stalled note never
+        // blocks an hour from syncing, or the reverse.
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs() as i64;
+        match crate::sync::sync_work_summaries(db, &config.agent_id, &base, now) {
+            Ok(n) if n > 0 => println!("[Sync] Uploaded {n} work note(s) to the cloud."),
+            Ok(_) => {}
+            Err(e) => eprintln!("[Sync] {e}"),
+        }
     }
 }
 

--- a/daemon/src/db.rs
+++ b/daemon/src/db.rs
@@ -1217,6 +1217,58 @@ impl Database {
         rows.collect()
     }
 
+    /// Signed work notes waiting to upload, oldest first — but only those written more
+    /// than `correction_window_secs` ago (ADR 0019).
+    ///
+    /// The delay is the correction window. Nothing waits on the worker and no approval
+    /// exists, so the protection against a bad note reaching a client is that the note
+    /// sits on their own machine, visible in their own dashboard, before it travels.
+    pub fn get_unsynced_summaries(
+        &self,
+        now_ts: i64,
+        correction_window_secs: i64,
+        limit: u32,
+    ) -> Result<Vec<WorkSummary>> {
+        let cutoff = now_ts - correction_window_secs;
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT id, period_start, period_end, summary_text, generated_at, revision,
+                    withdrawn, hash, parent_hash, signature, scheme_version, prompt_hash
+             FROM work_summaries
+             WHERE signature IS NOT NULL AND synced = 0 AND withdrawn = 0
+               AND generated_at <= ?1
+             ORDER BY id ASC
+             LIMIT ?2",
+        )?;
+        let rows = stmt.query_map(params![cutoff, limit], |row| {
+            Ok(WorkSummary {
+                id: row.get(0)?,
+                period_start: row.get(1)?,
+                period_end: row.get(2)?,
+                summary_text: row.get(3)?,
+                generated_at: row.get(4)?,
+                revision: row.get(5)?,
+                withdrawn: row.get::<_, i64>(6)? != 0,
+                hash: row.get(7)?,
+                parent_hash: row.get(8)?,
+                signature: row.get(9)?,
+                scheme_version: row.get(10).unwrap_or(SUMMARY_SCHEME_VERSION),
+                prompt_hash: row.get(11).unwrap_or_default(),
+            })
+        })?;
+        rows.collect()
+    }
+
+    /// Mark one note row uploaded.
+    pub fn mark_summary_synced(&self, id: i64) -> Result<()> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "UPDATE work_summaries SET synced = 1 WHERE id = ?1",
+            params![id],
+        )?;
+        Ok(())
+    }
+
     /// Whether a period already has a summary, at any revision. The generator uses this
     /// to stay idempotent across restarts.
     pub fn has_work_summary(&self, period_start: i64) -> Result<bool> {
@@ -2522,6 +2574,121 @@ e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855|CONFIGHASH|PARE
             db.has_work_summary(86_400).unwrap(),
             "the generator still knows this period was written"
         );
+    }
+
+    #[test]
+    fn test_correction_window_holds_notes_back_and_withdrawal_stops_them() {
+        // The window is the only thing standing between a bad note and a client, since
+        // nothing waits for approval. A fresh note must not be uploadable, and a note
+        // withdrawn during the window must never become uploadable at all.
+        let db = create_test_db();
+        let keys = crate::config::generate_enrollment_keys("tok");
+        let signer = SlotSigner {
+            public_key: &keys.public_key,
+            private_key: &keys.private_key,
+        };
+        let now = 1_786_800_000;
+        let window = 12 * 3600;
+
+        db.insert_work_summary(86_400, 172_800, "Fresh note.", now, "ph", Some(&signer))
+            .unwrap();
+        assert!(
+            db.get_unsynced_summaries(now, window, 50)
+                .unwrap()
+                .is_empty(),
+            "a note written just now has not cleared the correction window"
+        );
+
+        // Same note, once the window has passed.
+        let ready = db.get_unsynced_summaries(now + window, window, 50).unwrap();
+        assert_eq!(ready.len(), 1, "after the window it is ready to travel");
+        assert_eq!(ready[0].summary_text, "Fresh note.");
+
+        db.withdraw_work_summary(86_400).unwrap();
+        assert!(
+            db.get_unsynced_summaries(now + window, window, 50)
+                .unwrap()
+                .is_empty(),
+            "a withdrawn note never travels, window or not"
+        );
+    }
+
+    #[test]
+    fn test_synced_notes_are_not_re_uploaded() {
+        let db = create_test_db();
+        let keys = crate::config::generate_enrollment_keys("tok");
+        let signer = SlotSigner {
+            public_key: &keys.public_key,
+            private_key: &keys.private_key,
+        };
+        let now = 1_786_800_000;
+        let id = db
+            .insert_work_summary(86_400, 172_800, "Note.", now - 86_400, "ph", Some(&signer))
+            .unwrap();
+
+        assert_eq!(db.get_unsynced_summaries(now, 3600, 50).unwrap().len(), 1);
+        db.mark_summary_synced(id).unwrap();
+        assert!(db.get_unsynced_summaries(now, 3600, 50).unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_unsigned_notes_are_never_uploaded() {
+        // An unsigned note is a local artifact of an unenrolled machine. Uploading one
+        // would put text on a client's page that nothing can verify.
+        let db = create_test_db();
+        let now = 1_786_800_000;
+        db.insert_work_summary(86_400, 172_800, "Unsigned.", now - 86_400, "ph", None)
+            .unwrap();
+        assert!(db.get_unsynced_summaries(now, 3600, 50).unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_summary_canonical_vector_matches_cloud() {
+        // Cross-language alignment vector (ADR 0019), mirrored by the cloud's
+        // canonicalSummaryPayload test. A one-character drift on either side makes
+        // every note unverifiable — and a note is the part a client actually reads.
+        let note = "Reworked the checkout flow.";
+        let note_hash = sha256_hex(note);
+
+        let v1 =
+            canonical_summary_payload(1, "PUBKEY", 86_400, 172_800, 172_900, 0, note, "", "PARENT");
+        assert_eq!(
+            v1,
+            format!("tenby10-summary|v1|PUBKEY|86400|172800|172900|0|{note_hash}|PARENT")
+        );
+
+        let v2 = canonical_summary_payload(
+            2,
+            "PUBKEY",
+            86_400,
+            172_800,
+            172_900,
+            0,
+            note,
+            "PROMPTHASH",
+            "PARENT",
+        );
+        assert_eq!(
+            v2,
+            format!(
+                "tenby10-summary|v2|PUBKEY|86400|172800|172900|0|{note_hash}|PROMPTHASH|PARENT"
+            )
+        );
+
+        // The note is folded through SHA-256, so its text can never inject the delimiter.
+        let evil = canonical_summary_payload(
+            2,
+            "PUBKEY",
+            86_400,
+            172_800,
+            172_900,
+            0,
+            "a|b|c",
+            "PROMPTHASH",
+            "PARENT",
+        );
+        assert!(!evil.contains("a|b|c"));
+        assert!(evil.contains(&sha256_hex("a|b|c")));
     }
 
     #[test]

--- a/daemon/src/sync.rs
+++ b/daemon/src/sync.rs
@@ -152,3 +152,72 @@ pub fn sync_signed_slots(db: &Database, agent_id: &str, base_url: &str) -> Resul
     }
     Ok(uploaded)
 }
+
+/// How long a note sits on the worker's machine before it can travel (ADR 0019).
+///
+/// This is the correction window. There is no approval step and nothing waits on the
+/// worker, so what protects them from a bad note reaching a client is time: the note
+/// appears in their own dashboard first, and they can revise or withdraw it. Twelve
+/// hours means a note written at the close of one day leaves around the middle of the
+/// next — after an ordinary person has had a morning to look.
+pub const SUMMARY_CORRECTION_WINDOW_SECS: i64 = 12 * 3600;
+
+fn summary_payload(agent_id: &str, note: &crate::db::WorkSummary) -> serde_json::Value {
+    serde_json::json!({
+        "agent_id": agent_id,
+        "scheme_version": note.scheme_version,
+        "period_start": note.period_start,
+        "period_end": note.period_end,
+        "generated_at": note.generated_at,
+        "revision": note.revision,
+        // The text itself travels: it exists to be read by whoever receives a link.
+        // Its SHA-256 is inside the signature, so what lands is provably what was signed.
+        "summary_text": note.summary_text,
+        "prompt_hash": note.prompt_hash,
+        "ledger": { "hash": note.hash, "parent_hash": note.parent_hash },
+        "signature": note.signature,
+    })
+}
+
+/// Upload work notes that have cleared the correction window, oldest first (ADR 0019).
+///
+/// Stops at the first rejection, like slots: notes are a hash chain too, and a gap would
+/// break every note behind it. Withdrawn notes are never uploaded — withdrawing before
+/// the window closes means the note simply never travels.
+pub fn sync_work_summaries(
+    db: &Database,
+    agent_id: &str,
+    base_url: &str,
+    now_ts: i64,
+) -> Result<usize, String> {
+    if agent_id.is_empty() {
+        return Ok(0);
+    }
+    let notes = db
+        .get_unsynced_summaries(now_ts, SUMMARY_CORRECTION_WINDOW_SECS, 50)
+        .map_err(|e| format!("could not read unsynced work notes: {e}"))?;
+
+    let client = reqwest::blocking::Client::new();
+    let url = format!("{base_url}/api/v1/summaries");
+    let mut uploaded = 0usize;
+
+    for note in notes {
+        let resp = client
+            .post(&url)
+            .json(&summary_payload(agent_id, &note))
+            .send()
+            .map_err(|e| format!("work note upload request failed: {e}"))?;
+
+        if !resp.status().is_success() {
+            return Err(format!(
+                "work note for {} rejected: HTTP {} — stopping this sync",
+                note.period_start,
+                resp.status()
+            ));
+        }
+        db.mark_summary_synced(note.id)
+            .map_err(|e| format!("could not mark work note {} synced: {e}", note.id))?;
+        uploaded += 1;
+    }
+    Ok(uploaded)
+}


### PR DESCRIPTION
## Summary

Closes #67. Client half of the sync slice for #60 (ADR 0019). Signed work notes upload to `/api/v1/summaries` once they have cleared a twelve-hour correction window. The receiving endpoint ships first, so nothing here posts into a 404.

## The correction window is the protection

There is no approval step and nothing waits on the user — that was the explicit design call. So what stands between a bad note and a client is time: the note appears in the user's own dashboard first, and they can revise or withdraw it. A note written at the close of one day leaves around the middle of the next, after an ordinary person has had a morning to look at it.

Two hard rules back it up:

- **Withdrawn notes never upload.** Withdrawing inside the window means the note simply never travels.
- **Unsigned notes never upload.** An unsigned note is a local artifact of an unenrolled machine; putting text on a client's page that nothing can verify is the one thing this feature exists to avoid.

## Chain behaviour

Notes upload oldest-first and stop at the first rejection, exactly like slots — but on their own chain, so a stalled note never blocks an hour from syncing, or the reverse.

## Tests

103 green, including the three that matter here: a fresh note is not uploadable, the same note is once the window passes, and a note withdrawn during the window never becomes uploadable at all. Plus synced-notes-are-not-re-uploaded and unsigned-notes-never-travel. Clippy and fmt clean.

## Known gap, tracked

Once a note has synced there is currently no way to withdraw it from the cloud — withdrawal is outside the signed payload by design, so it cannot ride the ingestion endpoint as an unsigned flag. Tracked as a blocker on the verified-page render (tenby10-cloud#141): a synced note must not become visible to clients until withdrawal can propagate.