### PR TITLE
refactor: say "active time" instead of "billable" in the UI

### DIFF
--- a/daemon/src/dashboard.rs
+++ b/daemon/src/dashboard.rs
@@ -1058,7 +1058,7 @@ async fn serve_dashboard_html() -> impl IntoResponse {
             <div class="glass-card" style="flex: 1; display: flex; justify-content: space-between; align-items: center; padding: 1.2rem 2.5rem;">
                 <div class="metric-item" style="border: none; background: transparent; padding: 0;">
                     <span class="metric-value" id="stat-billable" style="font-size: 3rem; color: var(--accent-green);">-</span>
-                    <span class="metric-label" id="label-billable" style="font-size: 1rem;">Billable Today</span>
+                    <span class="metric-label" id="label-billable" style="font-size: 1rem;">Active Time Today</span>
                     <span class="metric-hint" id="hint-billable" style="font-size: 0.72rem; color: var(--text-muted);">&nbsp;</span>
                 </div>
                 <div class="metric-item" style="border: none; background: transparent; padding: 0;">
@@ -1569,7 +1569,7 @@ async fn serve_dashboard_html() -> impl IntoResponse {
             let billableSlots = 0;
             let daysRun = 0;
 
-            let labelBillable = 'Billable';
+            let labelBillable = 'Active Time';
             let labelFocus = 'Avg Focus';
             let labelDays = 'Days Run';
             
@@ -1577,7 +1577,7 @@ async fn serve_dashboard_html() -> impl IntoResponse {
             
             if (currentViewMode === 'daily') {
                 if (daysMap[currentDateKey]) relevantDays.push(daysMap[currentDateKey]);
-                labelBillable = 'Billable Today';
+                labelBillable = 'Active Time Today';
                 labelFocus = 'Focus Today';
                 labelDays = 'Logged Slots';
             } else if (currentViewMode === 'weekly') {
@@ -1591,7 +1591,7 @@ async fn serve_dashboard_html() -> impl IntoResponse {
                     const key = `${y}-${m}-${day}`;
                     if (daysMap[key]) relevantDays.push(daysMap[key]);
                 }
-                labelBillable = 'Billable This Week';
+                labelBillable = 'Active Time This Week';
                 labelFocus = 'Focus This Week';
                 labelDays = 'Active Days';
             } else if (currentViewMode === 'monthly') {
@@ -1602,7 +1602,7 @@ async fn serve_dashboard_html() -> impl IntoResponse {
                     const key = `${y}-${m}-${String(d).padStart(2, '0')}`;
                     if (daysMap[key]) relevantDays.push(daysMap[key]);
                 }
-                labelBillable = 'Billable This Month';
+                labelBillable = 'Active Time This Month';
                 labelFocus = 'Focus This Month';
                 labelDays = 'Active Days';
             }

--- a/desktop/src/dashboard.html
+++ b/desktop/src/dashboard.html
@@ -33,7 +33,7 @@
             <div class="glass-card" style="flex: 1; display: flex; justify-content: space-between; align-items: center; padding: 1.2rem 2.5rem;">
                 <div class="metric-item" style="border: none; background: transparent; padding: 0;">
                     <span class="metric-value" id="stat-billable" style="font-size: 3rem; color: var(--accent-green);">-</span>
-                    <span class="metric-label" id="label-billable" style="font-size: 1rem;">Billable Today</span>
+                    <span class="metric-label" id="label-billable" style="font-size: 1rem;">Active Time Today</span>
                     <span class="metric-hint" id="hint-billable" style="font-size: 0.72rem; color: var(--text-muted);">&nbsp;</span>
                 </div>
                 <div class="metric-item" style="border: none; background: transparent; padding: 0;">

--- a/desktop/src/dashboard.js
+++ b/desktop/src/dashboard.js
@@ -411,7 +411,7 @@ function goHome() {
             let billableSlots = 0;
             let daysRun = 0;
 
-            let labelBillable = 'Billable';
+            let labelBillable = 'Active Time';
             let labelFocus = 'Avg Focus';
             let labelDays = 'Days Run';
             
@@ -419,7 +419,7 @@ function goHome() {
             
             if (currentViewMode === 'daily') {
                 if (daysMap[currentDateKey]) relevantDays.push(daysMap[currentDateKey]);
-                labelBillable = 'Billable Today';
+                labelBillable = 'Active Time Today';
                 labelFocus = 'Focus Today';
                 labelDays = 'Logged Slots';
             } else if (currentViewMode === 'weekly') {
@@ -433,7 +433,7 @@ function goHome() {
                     const key = `${y}-${m}-${day}`;
                     if (daysMap[key]) relevantDays.push(daysMap[key]);
                 }
-                labelBillable = 'Billable This Week';
+                labelBillable = 'Active Time This Week';
                 labelFocus = 'Focus This Week';
                 labelDays = 'Active Days';
             } else if (currentViewMode === 'monthly') {
@@ -444,7 +444,7 @@ function goHome() {
                     const key = `${y}-${m}-${String(d).padStart(2, '0')}`;
                     if (daysMap[key]) relevantDays.push(daysMap[key]);
                 }
-                labelBillable = 'Billable This Month';
+                labelBillable = 'Active Time This Month';
                 labelFocus = 'Focus This Month';
                 labelDays = 'Active Days';
             }

--- a/desktop/src/index.html
+++ b/desktop/src/index.html
@@ -37,7 +37,7 @@
       <!-- Main Focus Card -->
       <div class="focus-card">
         <div style="display: flex; flex-direction: column; align-items: center; justify-content: center; padding: 0.5rem 0 1.5rem 0;">
-          <span style="font-size: 0.7rem; text-transform: uppercase; letter-spacing: 2px; color: #6b7280; font-weight: 700; margin-bottom: 0.35rem;">Billable Today</span>
+          <span style="font-size: 0.7rem; text-transform: uppercase; letter-spacing: 2px; color: #6b7280; font-weight: 700; margin-bottom: 0.35rem;">Active Time Today</span>
           <div style="display: flex; align-items: baseline; gap: 0.4rem;">
             <span id="metric-billable-time-main" style="font-size: 3rem; font-weight: 800; color: #10b981; line-height: 1;">0m</span>
           </div>
@@ -184,7 +184,7 @@
             </div>
             <p class="desc">
               Once a day is over, your AI writes a short note of what was worked on, from
-              your billable time. It appears in your log, and on any link you share.
+              your active time. It appears in your log, and on any link you share.
             </p>
 
             <div class="form-group" id="summary-prompt-group">


### PR DESCRIPTION
closes #76

## Summary

The app can verify that time was actively worked. Whether that time is *billable* is an invoicing decision that belongs to the user, so the UI now reports what it actually measures and leaves the billing call to the person sending the invoice.

## What changes

- Fat client hero label: `Billable Today` → `Active Time Today`
- Dashboard stat labels (desktop `dashboard.js` and the daemon-served `dashboard.rs` copy): `Billable {Today,This Week,This Month}` → `Active Time {…}`
- Work-note disclosure in Settings: "from your billable time" → "from your active time"

## Out of scope

Copy only. Element ids (`stat-billable`, `metric-billable-time-main`), the `billable_slots` API field, `BILLABLE_FOCUS_THRESHOLD`, and the ADR-0012 gate keep their names — the wire format and the scoring rule are untouched.

## Verification

`cargo fmt`, `cargo clippy -- -D warnings`, and `cargo test` green in both crates (110 daemon tests). The pre-commit hook ran the full gate.