### PR TITLE
fix: keep the dashboard where the user left it during refreshes

### DIFF
--- a/daemon/src/dashboard.rs
+++ b/daemon/src/dashboard.rs
@@ -1209,6 +1209,9 @@ async fn serve_dashboard_html() -> impl IntoResponse {
         let availableDates = [];
         let currentDateKey = null;
         let currentViewMode = 'daily';
+        // Set once the landing date and view have been chosen, so the 15s poll never
+        // re-chooses them under a user who is browsing (#78).
+        let positionInitialized = false;
         let weekStartDay = parseInt(localStorage.getItem('weekStartDay') || '1', 10); // 1 = Monday, 0 = Sunday
 
         // Fetch dashboard data
@@ -1238,37 +1241,46 @@ async fn serve_dashboard_html() -> impl IntoResponse {
                 }
                 
                 processSlots();
-                
-                // Determine initial date
-                const urlParams = getParamsFromUrl();
-                if (urlParams.date) {
-                    currentDateKey = urlParams.date;
-                } else if (availableDates.length > 0) {
-                    // Default to the most recent date with data
-                    currentDateKey = availableDates[availableDates.length - 1];
-                } else {
-                    // Fallback to today's date in YYYY-MM-DD local format
-                    const today = new Date();
-                    const year = today.getFullYear();
-                    const month = String(today.getMonth() + 1).padStart(2, '0');
-                    const day = String(today.getDate()).padStart(2, '0');
-                    currentDateKey = `${year}-${month}-${day}`;
+
+                // Where the user is looking is theirs, not the poll's. This runs once, on the
+                // first load; every later refresh below only re-renders whatever day, week or
+                // month is currently open, so browsing the past isn't yanked back to today
+                // every 15 seconds (#78). The Today button is how you come back.
+                if (!positionInitialized) {
+                    positionInitialized = true;
+
+                    // Determine initial date. A deep link's ?date=&tab= only decides where the
+                    // page opens; after that the user's own navigation owns the position.
+                    const urlParams = getParamsFromUrl();
+                    if (urlParams.date) {
+                        currentDateKey = urlParams.date;
+                    } else if (availableDates.length > 0) {
+                        // Default to the most recent date with data
+                        currentDateKey = availableDates[availableDates.length - 1];
+                    } else {
+                        // Fallback to today's date in YYYY-MM-DD local format
+                        const today = new Date();
+                        const year = today.getFullYear();
+                        const month = String(today.getMonth() + 1).padStart(2, '0');
+                        const day = String(today.getDate()).padStart(2, '0');
+                        currentDateKey = `${year}-${month}-${day}`;
+                    }
+
+                    if (urlParams.tab) {
+                        currentViewMode = urlParams.tab;
+                    }
+
+                    document.getElementById('week-start-select').value = weekStartDay.toString();
+
+                    document.querySelectorAll('.view-tab').forEach(el => el.classList.remove('active'));
+                    const activeTab = document.getElementById(`tab-${currentViewMode}`);
+                    if (activeTab) activeTab.classList.add('active');
+
+                    document.getElementById('day-view-container').style.display = currentViewMode === 'daily' ? 'block' : 'none';
+                    document.getElementById('week-view-container').style.display = currentViewMode === 'weekly' ? 'block' : 'none';
+                    document.getElementById('month-view-container').style.display = currentViewMode === 'monthly' ? 'block' : 'none';
                 }
-                
-                if (urlParams.tab) {
-                    currentViewMode = urlParams.tab;
-                }
-                
-                document.getElementById('week-start-select').value = weekStartDay.toString();
-                
-                document.querySelectorAll('.view-tab').forEach(el => el.classList.remove('active'));
-                const activeTab = document.getElementById(`tab-${currentViewMode}`);
-                if (activeTab) activeTab.classList.add('active');
-                
-                document.getElementById('day-view-container').style.display = currentViewMode === 'daily' ? 'block' : 'none';
-                document.getElementById('week-view-container').style.display = currentViewMode === 'weekly' ? 'block' : 'none';
-                document.getElementById('month-view-container').style.display = currentViewMode === 'monthly' ? 'block' : 'none';
-                
+
                 renderCurrentView();
             } catch (err) {
                 console.error("Error fetching dashboard data", err);

--- a/desktop/src/dashboard.js
+++ b/desktop/src/dashboard.js
@@ -24,6 +24,9 @@ function goHome() {
         let availableDates = [];
         let currentDateKey = null;
         let currentViewMode = 'daily';
+        // Set once the landing date and view have been chosen, so the 15s poll never
+        // re-chooses them under a user who is browsing (#78).
+        let positionInitialized = false;
         let weekStartDay = parseInt(localStorage.getItem('weekStartDay') || '1', 10); // 1 = Monday, 0 = Sunday
 
         // Daily work notes (ADR 0019), keyed by YYYY-MM-DD, plus whether note
@@ -110,37 +113,45 @@ function goHome() {
                 }
                 
                 processSlots();
-                
-                // Determine initial date
-                const urlParams = getParamsFromUrl();
-                if (urlParams.date) {
-                    currentDateKey = urlParams.date;
-                } else if (availableDates.length > 0) {
-                    // Default to the most recent date with data
-                    currentDateKey = availableDates[availableDates.length - 1];
-                } else {
-                    // Fallback to today's date in YYYY-MM-DD local format
-                    const today = new Date();
-                    const year = today.getFullYear();
-                    const month = String(today.getMonth() + 1).padStart(2, '0');
-                    const day = String(today.getDate()).padStart(2, '0');
-                    currentDateKey = `${year}-${month}-${day}`;
+
+                // Where the user is looking is theirs, not the poll's. This runs once, on the
+                // first load; every later refresh below only re-renders whatever day, week or
+                // month is currently open, so browsing the past isn't yanked back to today
+                // every 15 seconds (#78). The Today button is how you come back.
+                if (!positionInitialized) {
+                    positionInitialized = true;
+
+                    // Determine initial date
+                    const urlParams = getParamsFromUrl();
+                    if (urlParams.date) {
+                        currentDateKey = urlParams.date;
+                    } else if (availableDates.length > 0) {
+                        // Default to the most recent date with data
+                        currentDateKey = availableDates[availableDates.length - 1];
+                    } else {
+                        // Fallback to today's date in YYYY-MM-DD local format
+                        const today = new Date();
+                        const year = today.getFullYear();
+                        const month = String(today.getMonth() + 1).padStart(2, '0');
+                        const day = String(today.getDate()).padStart(2, '0');
+                        currentDateKey = `${year}-${month}-${day}`;
+                    }
+
+                    if (urlParams.tab) {
+                        currentViewMode = urlParams.tab;
+                    }
+
+                    document.getElementById('week-start-select').value = weekStartDay.toString();
+
+                    document.querySelectorAll('.view-tab').forEach(el => el.classList.remove('active'));
+                    const activeTab = document.getElementById(`tab-${currentViewMode}`);
+                    if (activeTab) activeTab.classList.add('active');
+
+                    document.getElementById('day-view-container').style.display = currentViewMode === 'daily' ? 'block' : 'none';
+                    document.getElementById('week-view-container').style.display = currentViewMode === 'weekly' ? 'block' : 'none';
+                    document.getElementById('month-view-container').style.display = currentViewMode === 'monthly' ? 'block' : 'none';
                 }
-                
-                if (urlParams.tab) {
-                    currentViewMode = urlParams.tab;
-                }
-                
-                document.getElementById('week-start-select').value = weekStartDay.toString();
-                
-                document.querySelectorAll('.view-tab').forEach(el => el.classList.remove('active'));
-                const activeTab = document.getElementById(`tab-${currentViewMode}`);
-                if (activeTab) activeTab.classList.add('active');
-                
-                document.getElementById('day-view-container').style.display = currentViewMode === 'daily' ? 'block' : 'none';
-                document.getElementById('week-view-container').style.display = currentViewMode === 'weekly' ? 'block' : 'none';
-                document.getElementById('month-view-container').style.display = currentViewMode === 'monthly' ? 'block' : 'none';
-                
+
                 renderCurrentView();
             } catch (err) {
                 console.error("Error fetching dashboard data", err);


### PR DESCRIPTION
closes #78

## Summary

The 15-second poll re-ran the whole "determine initial date" block, so it re-chose the landing date and view on every refresh. In the desktop app that always resolved to the most recent day with data, because `getParamsFromUrl()` returns nulls there by design — a native window has no address bar to round-trip position through. Browsing any past day, week or month was undone within 15 seconds.

## What changes

- Landing date and view mode are chosen once, on first load, behind a `positionInitialized` flag
- Later polls only re-render whatever is open, so new slots for the day in view still arrive while the user stays put
- Applied to both deliberate mirrors: `desktop/src/dashboard.js` and the daemon-served copy in `daemon/src/dashboard.rs`

Coming back to the current day is what the Today button is for.

The daemon copy was already surviving by round-tripping `?date=&tab=` through the URL. Deep links still decide where that page opens; they just no longer override navigation afterwards.

## Verification

Served the daemon’s real embedded page with stubbed `/api/data` (four days of slots) and drove it in a browser:

| condition | before | after one poll |
|---|---|---|
| guard off, no URL params (the desktop bug) | 2026-08-10 | **2026-08-17** |
| guard on, no URL params (fixed) | 2026-08-10 | 2026-08-10 |

Across two full poll cycles with the fix in place, 13 samples showed no change to date, view, or the date picker.

`cargo fmt`, `cargo clippy -- -D warnings`, `cargo test` green in both crates (110 daemon tests); `node --check` clean on dashboard.js. Pre-commit hook ran the full gate.