### PR TITLE
fix: land the dashboard window centred and on screen

### DIFF
--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -169,25 +169,276 @@ async fn get_today_metrics(
     })
 }
 
+/// Compact "home" size, in logical pixels. Must stay in step with the window
+/// defaults *and* the `minWidth`/`minHeight` in `tauri.conf.json`.
+const COMPACT_SIZE: (f64, f64) = (800.0, 600.0);
+/// Preferred dashboard size, in logical pixels — enough for the 24×6 slot grid.
+const DASHBOARD_SIZE: (f64, f64) = (1200.0, 840.0);
+/// Breathing room kept between the window and the edges of the monitor work area,
+/// so the expanded dashboard never looks wedged against the Dock or a screen edge.
+const SCREEN_MARGIN: f64 = 24.0;
+
+/// UI-only window preferences. Deliberately its own file rather than another field on
+/// `config.json`, which belongs to the daemon and is read on the sync path.
+#[derive(serde::Serialize, serde::Deserialize, Default)]
+struct WindowPreferences {
+    /// Preferred dashboard size in logical pixels, as the user last left it.
+    #[serde(default)]
+    dashboard: Option<(f64, f64)>,
+}
+
+fn window_preferences_path() -> std::path::PathBuf {
+    let mut path = daemon::env::get_app_home();
+    path.push("window.json");
+    path
+}
+
+fn load_preferred_dashboard_size() -> Option<(f64, f64)> {
+    let raw = std::fs::read_to_string(window_preferences_path()).ok()?;
+    serde_json::from_str::<WindowPreferences>(&raw)
+        .ok()?
+        .dashboard
+}
+
+/// Best effort on purpose: a window preference is not worth failing navigation over,
+/// and the built-in default is a perfectly good fallback.
+fn save_preferred_dashboard_size(size: (f64, f64)) {
+    if let Ok(raw) = serde_json::to_string_pretty(&WindowPreferences {
+        dashboard: Some(size),
+    }) {
+        let _ = std::fs::write(window_preferences_path(), raw);
+    }
+}
+
+#[derive(Default)]
+struct DashboardWindowInner {
+    /// Where the compact window sat before the dashboard expanded it, so leaving the
+    /// dashboard puts it back exactly where the user had it.
+    compact: Option<(tauri::PhysicalPosition<i32>, tauri::PhysicalSize<u32>)>,
+    /// The inner size `resize_and_center` actually applied on the way in. Leaving the
+    /// dashboard only records a new preference when the size differs from this —
+    /// otherwise a size we clamped to fit a small screen would come back as the user's
+    /// stated preference on every screen after it.
+    applied: Option<tauri::PhysicalSize<u32>>,
+    /// Preferred dashboard size in logical pixels, mirrored from `window.json`.
+    preferred: Option<(f64, f64)>,
+    /// Whether `preferred` has been read from disk yet this run.
+    loaded: bool,
+}
+
+#[derive(Default)]
+struct DashboardWindow(std::sync::Mutex<DashboardWindowInner>);
+
+impl DashboardWindow {
+    /// Poison-tolerant: a panic elsewhere should not permanently wedge navigation.
+    fn lock(&self) -> std::sync::MutexGuard<'_, DashboardWindowInner> {
+        self.0
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+/// Work out the inner size and outer position for a `target`-logical-pixel window
+/// centred on a monitor work area. Pure geometry, all physical pixels, in tauri's
+/// top-left-origin screen space — split out from `resize_and_center` so the unit
+/// conversions and clamps can be tested without a live window.
+///
+/// The work area already excludes the menu bar and Dock, so clamping to it is what
+/// keeps a 1200×840 dashboard usable on a 1280×800 display. `chrome` is the title
+/// bar / frame thickness: `set_size` speaks inner size but `set_position` speaks
+/// outer position, so it is the outer rect that has to be fitted and centred.
+fn fit_centered(
+    target: (f64, f64),
+    scale: f64,
+    chrome: (u32, u32),
+    area_position: (i32, i32),
+    area_size: (u32, u32),
+) -> ((u32, u32), (i32, i32)) {
+    let to_physical = |logical: f64| (logical * scale).round() as u32;
+    let margin = to_physical(SCREEN_MARGIN) * 2;
+
+    let available_w = area_size.0.saturating_sub(margin + chrome.0);
+    let available_h = area_size.1.saturating_sub(margin + chrome.1);
+
+    // Never go under the window's own minimum: the OS would refuse the shrink and the
+    // centring maths would then be based on a size the window never actually took.
+    let width = to_physical(target.0)
+        .min(available_w)
+        .max(to_physical(COMPACT_SIZE.0));
+    let height = to_physical(target.1)
+        .min(available_h)
+        .max(to_physical(COMPACT_SIZE.1));
+
+    let outer_w = (width + chrome.0) as i32;
+    let outer_h = (height + chrome.1) as i32;
+    let position = (
+        area_position.0 + (area_size.0 as i32 - outer_w) / 2,
+        area_position.1 + (area_size.1 as i32 - outer_h) / 2,
+    );
+
+    ((width, height), position)
+}
+
+/// Resize `window` to `target` logical pixels and centre it on the work area of the
+/// monitor it is currently on.
+///
+/// The placement is computed here rather than delegated to `WebviewWindow::center`
+/// on purpose. On macOS that call lands on `NSWindow.center`, which runs straight
+/// away on the main thread while tao applies `set_size` *asynchronously* on the main
+/// dispatch queue. So the window gets centred at its old size and only then grows —
+/// and because `setContentSize:` pins the frame's bottom-left corner, it expands up
+/// and to the right, ending up off-centre and often under the menu bar. (`NSWindow`
+/// also centres above the vertical middle by design.) Issuing `set_size` and
+/// `set_position` back to back keeps both on that same queue, in order, so the window
+/// lands where we asked for it.
+fn resize_and_center(
+    window: &tauri::WebviewWindow,
+    target: (f64, f64),
+) -> Result<tauri::PhysicalSize<u32>, String> {
+    let outer = window.outer_size().map_err(|e| e.to_string())?;
+    let inner = window.inner_size().map_err(|e| e.to_string())?;
+    let chrome = (
+        outer.width.saturating_sub(inner.width),
+        outer.height.saturating_sub(inner.height),
+    );
+
+    // `current_monitor` is what makes this behave on a multi-monitor desk: the window
+    // expands on the screen it is already on, not always the primary.
+    let monitor = window
+        .current_monitor()
+        .map_err(|e| e.to_string())?
+        .or(window.primary_monitor().map_err(|e| e.to_string())?);
+
+    let Some(monitor) = monitor else {
+        // No monitor to fit against (headless / hot-unplugged): take the size as asked
+        // and leave the window where it is rather than guessing at a position.
+        let scale = window.scale_factor().map_err(|e| e.to_string())?;
+        let size = tauri::PhysicalSize::new(
+            (target.0 * scale).round() as u32,
+            (target.1 * scale).round() as u32,
+        );
+        window
+            .set_size(tauri::Size::Physical(size))
+            .map_err(|e| e.to_string())?;
+        return Ok(size);
+    };
+
+    let area = monitor.work_area();
+    let ((width, height), (x, y)) = fit_centered(
+        target,
+        monitor.scale_factor(),
+        chrome,
+        (area.position.x, area.position.y),
+        (area.size.width, area.size.height),
+    );
+
+    let size = tauri::PhysicalSize::new(width, height);
+    window
+        .set_size(tauri::Size::Physical(size))
+        .map_err(|e| e.to_string())?;
+    window
+        .set_position(tauri::Position::Physical(tauri::PhysicalPosition::new(
+            x, y,
+        )))
+        .map_err(|e| e.to_string())?;
+
+    Ok(size)
+}
+
 /// Resize the main window when entering/leaving the in-window activity dashboard.
 /// The dashboard renders as a view *inside* the existing window (no browser, no
-/// second OS window); it just needs more room than the compact metrics home. When
-/// `expand` is true the window grows to fit the 24×6 slot grid; on exit it snaps
-/// back to the compact size and re-centers.
+/// second OS window); it just needs more room than the compact metrics home.
+///
+/// Entering expands to the user's preferred dashboard size — or the built-in default
+/// the first time — clamped to the screen and centred. Leaving puts the window back
+/// exactly where the compact view was, and records the dashboard size if the user
+/// resized it by hand.
 #[tauri::command]
-async fn set_dashboard_mode(app: tauri::AppHandle, expand: bool) -> Result<(), String> {
-    if let Some(window) = app.get_webview_window("main") {
-        let size = if expand {
-            tauri::LogicalSize::new(1200.0, 840.0)
-        } else {
-            tauri::LogicalSize::new(800.0, 600.0)
+async fn set_dashboard_mode(
+    app: tauri::AppHandle,
+    dashboard_window: tauri::State<'_, DashboardWindow>,
+    expand: bool,
+) -> Result<(), String> {
+    let Some(window) = app.get_webview_window("main") else {
+        return Ok(());
+    };
+
+    if expand {
+        let target = {
+            let mut state = dashboard_window.lock();
+            if !state.loaded {
+                state.preferred = load_preferred_dashboard_size();
+                state.loaded = true;
+            }
+            if let (Ok(position), Ok(size)) = (window.outer_position(), window.inner_size()) {
+                state.compact = Some((position, size));
+            }
+            state.preferred.unwrap_or(DASHBOARD_SIZE)
         };
-        window
-            .set_size(tauri::Size::Logical(size))
-            .map_err(|e| e.to_string())?;
-        let _ = window.center();
+
+        let applied = resize_and_center(&window, target)?;
+        dashboard_window.lock().applied = Some(applied);
+    } else {
+        let (compact, applied) = {
+            let mut state = dashboard_window.lock();
+            (state.compact.take(), state.applied.take())
+        };
+
+        remember_hand_resize(&window, &dashboard_window, applied);
+
+        match compact {
+            // Same ordering rule as `resize_and_center`: size first, then position.
+            Some((position, size)) => {
+                window
+                    .set_size(tauri::Size::Physical(size))
+                    .map_err(|e| e.to_string())?;
+                window
+                    .set_position(tauri::Position::Physical(position))
+                    .map_err(|e| e.to_string())?;
+            }
+            None => {
+                resize_and_center(&window, COMPACT_SIZE)?;
+            }
+        }
     }
+
     Ok(())
+}
+
+/// Persist the dashboard size if the user dragged the window to a size of their own.
+///
+/// Comparing against `applied` — what `resize_and_center` actually set on the way in —
+/// rather than against the default is the point: on a screen too small for the
+/// preferred size we hand the window a clamped size, and saving *that* would quietly
+/// shrink the dashboard everywhere from then on. A couple of pixels of slack absorbs
+/// rounding through the logical/physical conversion.
+fn remember_hand_resize(
+    window: &tauri::WebviewWindow,
+    dashboard_window: &DashboardWindow,
+    applied: Option<tauri::PhysicalSize<u32>>,
+) {
+    let (Some(applied), Ok(current), Ok(scale)) =
+        (applied, window.inner_size(), window.scale_factor())
+    else {
+        return;
+    };
+
+    let resized =
+        applied.width.abs_diff(current.width) > 2 || applied.height.abs_diff(current.height) > 2;
+    if !resized {
+        return;
+    }
+
+    let preferred = (
+        (current.width as f64 / scale).round(),
+        (current.height as f64 / scale).round(),
+    );
+
+    let mut state = dashboard_window.lock();
+    if state.preferred != Some(preferred) {
+        state.preferred = Some(preferred);
+        save_preferred_dashboard_size(preferred);
+    }
 }
 
 /// Recent slot summaries for the dashboard (newest first).
@@ -465,6 +716,7 @@ pub fn run() {
         .plugin(tauri_plugin_dialog::init())
         .manage(state.clone())
         .manage(db.clone())
+        .manage(DashboardWindow::default())
         .invoke_handler(tauri::generate_handler![
             enroll_agent,
             toggle_tracking,
@@ -586,4 +838,169 @@ pub fn run() {
         })
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
+}
+
+#[cfg(test)]
+mod window_geometry_tests {
+    use super::{fit_centered, COMPACT_SIZE, DASHBOARD_SIZE, SCREEN_MARGIN};
+
+    /// Title bar thickness in physical pixels for a given scale factor.
+    fn chrome(scale: f64) -> (u32, u32) {
+        (0, (28.0 * scale) as u32)
+    }
+
+    /// The outer window must land fully inside the work area, and the gaps left and
+    /// right (top and bottom) must match — that is what "centred" has to mean here.
+    fn assert_centered_inside(
+        (width, height): (u32, u32),
+        (x, y): (i32, i32),
+        chrome: (u32, u32),
+        area_position: (i32, i32),
+        area_size: (u32, u32),
+    ) {
+        let outer_w = (width + chrome.0) as i32;
+        let outer_h = (height + chrome.1) as i32;
+
+        let left = x - area_position.0;
+        let right = (area_position.0 + area_size.0 as i32) - (x + outer_w);
+        let top = y - area_position.1;
+        let bottom = (area_position.1 + area_size.1 as i32) - (y + outer_h);
+
+        assert!(
+            left >= 0 && right >= 0,
+            "overflows horizontally: {left}/{right}"
+        );
+        assert!(
+            top >= 0 && bottom >= 0,
+            "overflows vertically: {top}/{bottom}"
+        );
+        // Odd leftovers make one side a pixel wider; anything more is not centred.
+        assert!(
+            (left - right).abs() <= 1,
+            "off-centre horizontally: {left}/{right}"
+        );
+        assert!(
+            (top - bottom).abs() <= 1,
+            "off-centre vertically: {top}/{bottom}"
+        );
+    }
+
+    /// 14" MacBook Pro, 1512×982 logical at 2x, menu bar taken off the top. The
+    /// dashboard fits at its full preferred size and sits dead centre.
+    #[test]
+    fn retina_laptop_keeps_the_preferred_size() {
+        let area_position = (0, 74); // menu bar, physical
+        let area_size = (3024, 1890);
+        let (size, position) =
+            fit_centered(DASHBOARD_SIZE, 2.0, chrome(2.0), area_position, area_size);
+
+        assert_eq!(size, (2400, 1680), "1200x840 logical at 2x");
+        assert_centered_inside(size, position, chrome(2.0), area_position, area_size);
+    }
+
+    /// 1280×800 at 1x — the case the old code got wrong. 840 points tall plus a title
+    /// bar does not fit under the menu bar, so the height has to give.
+    #[test]
+    fn short_screen_clamps_height_instead_of_overflowing() {
+        let area_position = (0, 25);
+        let area_size = (1280, 775);
+        let (size, position) =
+            fit_centered(DASHBOARD_SIZE, 1.0, chrome(1.0), area_position, area_size);
+
+        assert!(
+            size.1 < DASHBOARD_SIZE.1 as u32,
+            "height should be clamped, got {}",
+            size.1
+        );
+        assert_eq!(size.0, DASHBOARD_SIZE.0 as u32, "width still fits");
+        assert_centered_inside(size, position, chrome(1.0), area_position, area_size);
+
+        // The margin is honoured, not eaten, when clamping.
+        let gap = position.1 - area_position.1;
+        assert!(gap >= SCREEN_MARGIN as i32, "margin collapsed: {gap}");
+    }
+
+    /// A work area too small even for the compact window: the clamp must not drive the
+    /// request below `minWidth`/`minHeight`, which the OS would refuse anyway — that
+    /// would leave the centring maths based on a size the window never took.
+    #[test]
+    fn never_requests_less_than_the_window_minimum() {
+        let (size, _) = fit_centered(DASHBOARD_SIZE, 1.0, chrome(1.0), (0, 0), (700, 500));
+
+        assert_eq!(size.0, COMPACT_SIZE.0 as u32);
+        assert_eq!(size.1, COMPACT_SIZE.1 as u32);
+    }
+
+    /// Each axis clamps on its own: a wide-but-short work area gives up height only.
+    #[test]
+    fn clamps_each_axis_independently() {
+        let (size, _) = fit_centered(DASHBOARD_SIZE, 1.0, chrome(1.0), (0, 0), (900, 640));
+
+        assert_eq!(
+            size.0, 852,
+            "width follows the work area, still above the minimum"
+        );
+        assert_eq!(
+            size.1, COMPACT_SIZE.1 as u32,
+            "height bottoms out at the minimum"
+        );
+    }
+
+    /// A monitor to the left of the primary has a negative origin. The window has to
+    /// follow the work area rather than centring on the global origin.
+    #[test]
+    fn centers_on_a_secondary_monitor_with_negative_origin() {
+        let area_position = (-2560, -140);
+        let area_size = (2560, 1400);
+        let (size, position) =
+            fit_centered(DASHBOARD_SIZE, 1.0, chrome(1.0), area_position, area_size);
+
+        assert!(
+            position.0 < 0,
+            "should stay on the left-hand monitor, got x={}",
+            position.0
+        );
+        assert_centered_inside(size, position, chrome(1.0), area_position, area_size);
+    }
+
+    /// A remembered size from a roomier monitor must still be fitted to the screen the
+    /// window is actually on, rather than reopening off the bottom of it.
+    #[test]
+    fn remembered_size_larger_than_the_screen_is_clamped() {
+        let area_position = (0, 25);
+        let area_size = (1440, 875);
+        let remembered = (1900.0, 1200.0);
+        let (size, position) = fit_centered(remembered, 1.0, chrome(1.0), area_position, area_size);
+
+        assert!(size.0 < remembered.0 as u32 && size.1 < remembered.1 as u32);
+        assert_centered_inside(size, position, chrome(1.0), area_position, area_size);
+    }
+
+    /// `window.json` is written by us but read back after upgrades, so it has to
+    /// survive a missing field rather than throwing the preference away on a parse
+    /// error and silently reverting to the default.
+    #[test]
+    fn window_preferences_round_trip() {
+        let raw = serde_json::to_string(&super::WindowPreferences {
+            dashboard: Some((1400.0, 900.0)),
+        })
+        .expect("serialises");
+        let parsed: super::WindowPreferences = serde_json::from_str(&raw).expect("parses");
+        assert_eq!(parsed.dashboard, Some((1400.0, 900.0)));
+
+        let empty: super::WindowPreferences = serde_json::from_str("{}").expect("parses empty");
+        assert_eq!(empty.dashboard, None);
+    }
+
+    /// Collapsing back to the compact size is the same computation, so it centres too.
+    #[test]
+    fn compact_size_is_centered_as_well() {
+        let area_position = (0, 74);
+        let area_size = (3024, 1890);
+        let (size, position) =
+            fit_centered(COMPACT_SIZE, 2.0, chrome(2.0), area_position, area_size);
+
+        assert_eq!(size, (1600, 1200));
+        assert_centered_inside(size, position, chrome(2.0), area_position, area_size);
+    }
 }


### PR DESCRIPTION
Closes #81

## Summary

Opening the dashboard grew the window but never placed it, so it had to be resized
and dragged back into position on every visit. This computes the placement instead
of delegating it, fits the window to the screen it is on, and remembers a dashboard
size you set by hand.

## Context

`set_dashboard_mode` called `set_size(...)` and then `window.center()`. On macOS
those take different paths through tao:

- `set_size` -> `util::set_content_size_async`, queued on the main dispatch queue
- `center()` -> `NSWindow.center()`, run immediately on the main thread

So the window was centred at its **old** 800x600 size and only then grown to
1200x840. `setContentSize:` pins the frame's bottom-left corner, so it expanded up
and to the right — off-centre, often with the title bar under the menu bar. The
same thing happened in reverse on exit, which is why it was wrong every time in
both directions.

Two further problems sat on top of the race: nothing clamped 1200x840 to the
screen, so it did not fit at all under the menu bar on a 1280x800 display, and
`NSWindow.center` sits above the vertical middle by design.

## Changes

- Compute the position here and issue `set_size` then `set_position`, so both queue
  on the same dispatch queue in order instead of racing.
- Fit the target to the current monitor's work area (menu bar and Dock already
  excluded), keeping a 24pt margin and flooring at the window's own 800x600 minimum
  so we never request a size the OS would refuse.
- Use `current_monitor()`, so on a multi-monitor desk it expands on the screen the
  window is already on.
- Restore the compact window exactly where it was on exit, instead of re-centring it.
- Remember a hand-resized dashboard in `window.json`, so the preferred size is the
  user's rather than the built-in default. The comparison is against the size we
  actually applied on the way in, not against the default — otherwise a size clamped
  to fit a small screen would be saved as a preference and quietly shrink the
  dashboard everywhere after that.

`window.json` is a new UI-only file in the app home, deliberately separate from
`config.json`, which belongs to the daemon and is read on the sync path.

## Tests

The geometry is split into a pure `fit_centered()` so the unit conversions and
clamps are covered without a live window: retina laptop keeps the full preferred
size, a short 1280x800 screen clamps height rather than overflowing, each axis
clamps independently, a sub-minimum work area never drives the request below the
window minimum, a secondary monitor with a negative origin centres on that monitor,
a remembered size larger than the screen is clamped, and the preferences file
survives a missing field.

## Not verified

I have not driven this in a running app — the geometry is unit tested and the
ordering is read off the tao/tauri sources, but the placement itself wants a pair of
eyes on a real screen. Worth a quick look on both the laptop display and an external
monitor before merging.