### PR TITLE
docs: stop SECURITY.md claiming the client captures the screen

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,8 +1,13 @@
 # Security Policy
 
-tenby10's desktop client runs as a background process that hooks global input and captures the
-screen, so we take security reports seriously and want them to reach us **privately** before they
-reach the public.
+tenby10's desktop client runs as a background process that hooks global input and reads the title
+of the active window, so we take security reports seriously and want them to reach us **privately**
+before they reach the public.
+
+It takes no screenshots — the screen-capture subsystem was removed outright rather than left
+switchable (ADR 0018), and there is no capture code in the client to report a bug in. macOS still
+asks for Screen Recording because it withholds *window titles* without it; the app reads titles, not
+pixels. See [`AUDIT.md`](AUDIT.md) §3 if you want to verify that before reporting anything.
 
 ## Reporting a vulnerability
 
@@ -35,7 +40,9 @@ steps or a proof-of-concept, and the impact you observed.
 
 - the background telemetry **daemon** (`daemon/`),
 - the **Tauri desktop app** (`desktop/`),
-- the local dashboard and local HTTP server,
+- the in-app dashboard, and the debug-only loopback HTTP server — note the installed app starts no
+  server and opens no port; it runs only for the standalone `daemon` binary with
+  `TENBY10_DEBUG_HTTP` set, and is in scope anyway,
 - local key handling, the signing/hash-chain ledger, and the anti-cheat / provenance code.
 
 **Out of scope:**


### PR DESCRIPTION
## Context

`SECURITY.md` opened by describing the client as a process that "hooks global input and captures the screen". The second half stopped being true when ADR 0018 removed the screenshot subsystem. Since `SECURITY.md` is the first file a researcher opens, it contradicted the client's headline claim before they reached the README or `AUDIT.md` §3, both of which are accurate.

The scope list had a quieter version of the same problem: it named "the local dashboard and local HTTP server" as though that server normally runs. The installed app opens no port — it exists only for the standalone `daemon` binary with `TENBY10_DEBUG_HTTP` set.

## Changes

- Opening line now says what the client does: hooks global input, reads the active window title.
- Adds a short paragraph stating there are no screenshots, and why macOS is still asked for Screen Recording (it withholds window titles otherwise), pointing at `AUDIT.md` §3 so a reader can check rather than believe.
- Scope list describes the loopback server accurately — still in scope, but the debug-only escape hatch it actually is.

## Verification

`git grep -niE "captures the screen"` returns nothing across tracked files. The README and `AUDIT.md` references to the removed subsystem are deliberately untouched: those are the accurate historical record, not stale claims.

closes #89