### PR TITLE
docs: stop the README claiming window titles never sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 **tenby10** is a privacy-first, source-available desktop activity tracker. A local background daemon measures your work activity on-device and turns it into a **tamper-evident, cryptographically-signed** record of your time — using only input *counts*, app names and window titles — never raw keystrokes, and never an image of your screen.
 
-Everything is stored locally under `~/.tenby10/`. If you enroll a device, only signed 10-minute *summaries* and your scoring configuration are synced — raw keystrokes and window titles are never synced to tenby10 (see [AUDIT.md](AUDIT.md)). It also operates on a **Bring Your Own Key (BYOK)** model: if you enable AI scoring, activity text (including window titles) goes from your machine straight to the LLM provider *you* configure — your key, your provider, never through tenby10. With local Ollama it stays fully on-device.
+Everything is stored locally under `~/.tenby10/`. If you enroll a device, what syncs is signed 10-minute *summaries*, your scoring configuration and, once you connect your own AI, one signed *work note* per finished day. **Raw keystrokes and raw window titles never reach tenby10.** The work note is a sentence your own AI writes *from* your window titles, so it is the one place title-*derived* text travels; **Privacy & Security Blueprint** below says what constrains it. [AUDIT.md §2](AUDIT.md#2-what-leaves-your-machine-network-egress-inventory) is the authoritative, field-by-field list of what leaves this machine. It also operates on a **Bring Your Own Key (BYOK)** model: connect a provider and activity text (including window titles) goes from your machine straight to the LLM provider *you* configure. Your key, your provider, never through tenby10. With local Ollama it stays fully on-device.
 
-> 🔍 **Don't trust — verify.** This is the full **source-available** client that runs on your machine. Before granting it input and screen access, read the **[Auditor's Guide (AUDIT.md)](AUDIT.md)**: it maps every privacy and fairness claim (no keylogging, no cloud exfiltration, fair scoring rules) to the exact source lines that prove it, and honestly lists where the code doesn't yet match our copy. An AI agent can follow it end-to-end to verify us.
+> 🔍 **Don't trust — verify.** This is the full **source-available** client that runs on your machine. Before granting it input and screen access, read the **[Auditor's Guide (AUDIT.md)](AUDIT.md)**: it maps every privacy and fairness claim (no keylogging, no screen capture, exactly what syncs, fair scoring rules) to the exact source lines that prove it, and honestly lists where the code doesn't yet match our copy. An AI agent can follow it end-to-end to verify us.
 
 ---
 
@@ -20,7 +20,7 @@ Everything is stored locally under `~/.tenby10/`. If you enroll a device, only s
     - **Development Mode**: When running from source in debug mode, the app automatically isolates itself to `~/.tenby10_dev/`.
     - **Environment Overrides**: Use `TENBY10_HOME` to override the base directory. `TENBY10_DEBUG_HTTP` opts the standalone daemon into a loopback debug server (off by default), and `TENBY10_PORT` sets its port (default: 5005).
 *   🛡️ **Tamper-Evident Ledger**: Each 10-minute slot summary is SHA-256 hash-chained over its **full** payload, so editing any stored field breaks the chain. Once you enroll, every slot is additionally **Ed25519-signed with your key**, so even a re-computed hash won't verify without that key. On a machine you control this is tamper-*evidence* and self-asserted authorship — not, by itself, third-party proof.
-*   🧠 **BYOK Local AI Scribe**: Connects directly to your own provider (OpenAI, Anthropic, or Gemini) to analyze active logs and generate professional work summaries. 
+*   🧠 **BYOK Local AI Scribe**: Connects directly to your own provider (OpenAI, Anthropic, Gemini, or any OpenAI-compatible endpoint, including a local Ollama) to score slots and write one short work note per finished day.
 *   🟢 **10-Minute Slot Standard**: Records your day in verifiable 10-minute slots, each hash-chained and — once you enroll — signed with your key.
 
 ---
@@ -40,7 +40,7 @@ The codebase is structured as a lightweight monorepo containing two core compone
                   ┌──────────────────────────────────────────────┐
                   │              Background Daemon               │
                   │   - Global OS Input Listeners (rdev)         │
-                  │   - Window Scraper (polling at 10s)          │
+                  │   - Window Scraper (one read per minute)     │
                   │   - Local DB & Cryptographic Ledger          │
                   └──────────────┬───────────────────────────────┘
                                  │ Tauri IPC (no network)
@@ -52,7 +52,7 @@ The codebase is structured as a lightweight monorepo containing two core compone
                   └──────────────────────────────────────────────┘
 ```
 
-1.  **Background Daemon (`/daemon`)**: A background service written in Rust that handles global OS input hooks, scrapes active window titles at a 10s interval, and maintains the local SQLite database (`tenby10.db`). **The installed app opens no network port** — the dashboard reads from the daemon over Tauri IPC. A loopback HTTP server exists in the codebase purely as a debugging escape hatch for the standalone `daemon` binary, and stays off unless `TENBY10_DEBUG_HTTP` is explicitly set.
+1.  **Background Daemon (`/daemon`)**: A background service written in Rust that handles global OS input hooks, reads the frontmost app and window title once per 60-second aggregation cycle, and maintains the local SQLite database (`tenby10.db`). **The installed app opens no network port** — the dashboard reads from the daemon over Tauri IPC. A loopback HTTP server exists in the codebase purely as a debugging escape hatch for the standalone `daemon` binary, and stays off unless `TENBY10_DEBUG_HTTP` is explicitly set.
 2.  **Desktop GUI (`/desktop`)**: A native desktop wrapper built using **Tauri (v2)** with a frosted glassmorphism settings interface, enabling cryptographic key enrollment and configuration management.
 
 ---
@@ -60,11 +60,12 @@ The codebase is structured as a lightweight monorepo containing two core compone
 ## 🔒 Privacy & Security Blueprint
 
 *   **No screen capture at all**: tenby10 never reads the pixels on your screen. Earlier versions saved one heavily-blurred JPEG per 10-minute slot; that subsystem was removed outright (ADR 0018) rather than left switchable, and upgrading deletes the old `screenshots/` folder. macOS still asks for Screen Recording because it withholds *window titles* without it — the app reads titles, not pixels.
-*   **Negligible Footprint**: Telemetry metrics consume well under **100 KB per active workday**, translating to a few MB of disk usage per year. No background database fragmentation or CPU spikes are caused by automated deletion/vacuum cycles.
+*   **Negligible Footprint**: Telemetry metrics consume well under **100 KB per active workday**, translating to a few MB of disk usage per year. There is no retention or vacuum cycle in the client, so nothing is deleted or compacted behind your back: what was recorded stays until you remove it.
 *   **On-device by default — you decide what leaves**: Nothing is uploaded until *you* choose to share verifiable reports (by enrolling a device). The split is deliberate:
-    - **Always stays on your machine**: raw keystrokes (only *counts* are kept — never the keys) and the full activity database under `~/.tenby10/`. Your screen is never captured at all.
-    - **Leaves only when you share a report**: signed 10-minute *summaries* (focus score, active/idle and input **counts**, app-category counts, a **hash** of any AI note) plus your scoring configuration — enough for a recipient to see the numbers and which rules produced them. Raw keystrokes and window titles are **never** uploaded.
-    - **Your own AI, opt-in and separate**: if you enable BYOK LLM scoring, activity text (including window titles) goes directly to *your* provider using *your* key — to your provider, never to tenby10.
+    - **Always stays on your machine**: raw keystrokes (only *counts* are kept — never the keys), raw window titles, and the full activity database under `~/.tenby10/`. Your screen is never captured at all.
+    - **Leaves only when you share a report**: signed 10-minute *summaries* plus your scoring configuration, enough for a recipient to see the numbers and which rules produced them. [AUDIT.md §2](AUDIT.md#2-what-leaves-your-machine-network-egress-inventory) lists every field of every request, and is the one place that list is maintained.
+    - **Your daily work note, once you connect an AI**: one or two sentences per finished day, written on your machine by *your* AI from your own window titles, then uploaded as text. It is on once an AI is configured and there is a switch in settings to turn it off. A raw title is never uploaded, but a sentence derived from one is, so three things constrain it. The daemon discards a note that reproduces a run of any of that day's window titles verbatim, before anything is signed; that check catches a quotation, not a paraphrase. The SHA-256 of the prompt that wrote the note is bound into the signed record, so a reader can see which rules were in force. And the note waits 12 hours on your machine, visible in your own dashboard first: revise or withdraw it inside that window and it never travels at all.
+    - **Your own AI, opt-in and separate**: connect a provider and activity text (including window titles) goes directly to *your* provider using *your* key, for slot scoring when the LLM engine is on and for writing the work note. To your provider, never to tenby10.
 
 ---
 


### PR DESCRIPTION
## TL;DR

The README's front-door claim, side by side:

- **Was:** "only signed 10-minute *summaries* and your scoring configuration are synced — raw keystrokes and window titles are never synced to tenby10"
- **Now:** "what syncs is signed 10-minute *summaries*, your scoring configuration and, once you connect your own AI, one signed *work note* per finished day. **Raw keystrokes and raw window titles never reach tenby10.** The work note is a sentence your own AI writes *from* your window titles, so it is the one place title-*derived* text travels"

Plus a pointer to `AUDIT.md` §2 as the one maintained egress list, so the README stops carrying a second copy that can rot. Docs only, `README.md` only. `closes #97`

## Context

Raw titles genuinely never travel; I re-verified that against the code before writing. No upload payload has a title field (`slot_payload`, `summary_payload`, `withdrawal_payload` in `daemon/src/sync.rs`). What changed since the claim was written is that work notes shipped (ADR 0019): `summary_payload` uploads `summary_text` to `POST /api/v1/summaries`, and that sentence is written by the user's own AI from `activity_digest`, which is built from window titles. So "never synced" reading as "nothing derived from a title ever travels" is the part that no longer holds.

`AUDIT.md` was corrected for this in #84/#86 and #87/#88. The README was not, and it is the file a sceptical reader hits before the one that explains the nuance. Two places asserting the same thing is what produced the drift, so this fixes the claim and then defers rather than restating the inventory.

Everything the new wording asserts is verified in this tree:

- 12-hour correction window: `SUMMARY_CORRECTION_WINDOW_SECS` in `daemon/src/sync.rs`, enforced in `get_unsynced_summaries` (`daemon/src/db.rs`), which also drops withdrawn notes. Withdraw inside the window and the note never travels.
- Prompt hash in the signed record: `prompt_hash` in `summary_payload`, folded into `canonical_summary_payload`.
- The #83 echo check: `note_quotes_a_title` (`daemon/src/untrusted.rs`), called before signing in `generate_pending_summaries` (`daemon/src/daemon.rs`), against every title of the day rather than just the ones the model saw. It catches a verbatim run, not a paraphrase, and the README says so in those terms.

## Changes

`README.md` only:

1. **The intro claim** restated as above, with `AUDIT.md` §2 named as the authoritative field-by-field list.
2. **The Privacy & Security Blueprint split** made to match: raw titles moved into "always stays on your machine", the per-field summary list replaced by a link to §2, and a new bullet for the daily work note carrying the three real constraints (verbatim-run refusal, prompt hash bound into the signature, 12-hour window to revise or withdraw).
3. **Three more stale claims caught in the same sweep:**
   - The window scraper reads once per 60-second aggregation cycle, not "at a 10s interval" (diagram and prose). The only 10s cadence left is the settings page's title-health probe, which stores nothing.
   - "No CPU spikes from automated deletion/vacuum cycles" described a subsystem that does not exist. There is no retention or vacuum code in `daemon/src`, so the sentence now says that instead.
   - The BYOK scribe bullet listed three hosted providers only, and framed AI egress as gated on "AI scoring". Work notes are not gated on `engine_mode`, and `get_llm_provider` accepts any OpenAI-compatible base URL including a local Ollama.

Links checked against this branch's HEAD: every relative link in `README.md` (`AUDIT.md`, `LICENSE`, `SECURITY.md`, `CONTRIBUTING.md`, `daemon/src/`, `.github/workflows/ci.yml`) resolves, and the two new `AUDIT.md#2-...` anchors match the current `## 2. What leaves your machine (network egress inventory)` heading. The README carries no `file#Lnnn` links, so there are no line numbers to re-pin.

### Not in this PR

`AUDIT.md` row 9 and the "Never sent" note in §2 still read as though the no-quoting rule is prompt-only ("Nothing inspects the sentence afterwards"), which the G3 entry in the same file contradicts now that #83 landed. Untouched here on purpose, and worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
