### PR TITLE
ci: harden the release pipeline and attest every published asset

### DIFF
--- a/.github/workflows/notarize-check.yml
+++ b/.github/workflows/notarize-check.yml
@@ -32,12 +32,12 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       # ---- Optional heavy path: only when real_build=true -------------------------------
       - name: Setup Node.js
         if: ${{ inputs.real_build }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: lts/*
           cache: 'npm'
@@ -45,7 +45,7 @@ jobs:
 
       - name: Install Rust toolchain
         if: ${{ inputs.real_build }}
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable branch, 2026-08-05
 
       - name: Install desktop dependencies and stage assets
         if: ${{ inputs.real_build }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,12 @@
 name: Release
 
+# Third-party actions are pinned to a full commit SHA, with the human-readable
+# version in a trailing comment. A tag or branch ref can be repointed by whoever
+# controls the upstream repo; a SHA cannot. This matters most in the `publish`
+# job, which holds the Apple signing identity and a contents:write token.
+# To bump one: resolve the new SHA (`gh api repos/<owner>/<repo>/commits/<tag>
+# -q .sha`) and update both the SHA and the comment.
+
 on:
   push:
     tags:
@@ -23,14 +30,14 @@ jobs:
       run:
         working-directory: daemon
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Stage assets
         run: |
           cp desktop/src-tauri/icons_prod/128x128.png daemon/src/logo.png
           cp desktop/src-tauri/icons_prod/32x32.png daemon/src/favicon.png
         working-directory: .
       - name: Cache dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: daemon
       - name: Check Formatting
@@ -47,7 +54,7 @@ jobs:
       run:
         working-directory: desktop/src-tauri
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Stage assets
         run: |
           mkdir -p desktop/src-tauri/icons
@@ -57,7 +64,7 @@ jobs:
           cp desktop/src-tauri/icons_prod/32x32.png daemon/src/favicon.png
         working-directory: .
       - name: Cache dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: desktop/src-tauri
       - name: Check Formatting
@@ -85,10 +92,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: lts/*
           cache: 'npm'
@@ -98,11 +105,14 @@ jobs:
         run: npm ci
         working-directory: desktop
 
+      # Pinned to the head of the action's `stable` branch. That branch's
+      # action.yml defaults `toolchain: stable`, so pinning freezes the *action
+      # code*, not the Rust release: rustup still resolves "stable" at run time.
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable branch, 2026-08-05
 
       - name: Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: |
             daemon
@@ -117,18 +127,27 @@ jobs:
           cp desktop/src-tauri/icons_prod/128x128.png daemon/src/logo.png
           cp desktop/src-tauri/icons_prod/32x32.png daemon/src/favicon.png
 
+      # The tag arrives through `env:` and is read as "$REF", so its text is
+      # never spliced into the script body. It is then checked against a strict
+      # numeric shape before being handed to jq via --arg.
       - name: Sync version from tag
         shell: bash
+        env:
+          REF: ${{ github.event.inputs.tag || github.ref_name }}
         run: |
-          REF="${{ github.event.inputs.tag || github.ref_name }}"
-          VERSION=${REF#v}
+          set -euo pipefail
+          VERSION="${REF#v}"
           # Windows MSI builds require strictly numeric versions (no -dev or -beta suffixes allowed)
-          VERSION=${VERSION%%-*}
+          VERSION="${VERSION%%-*}"
+          if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Tag '$REF' does not yield a MAJOR.MINOR.PATCH version (got '$VERSION')."
+            exit 1
+          fi
           echo "Syncing project files to version $VERSION"
           # Update tauri.conf.json
-          jq ".version = \"$VERSION\"" desktop/src-tauri/tauri.conf.json > tmp.json && mv tmp.json desktop/src-tauri/tauri.conf.json
+          jq --arg v "$VERSION" '.version = $v' desktop/src-tauri/tauri.conf.json > tmp.json && mv tmp.json desktop/src-tauri/tauri.conf.json
           # Update package.json
-          jq ".version = \"$VERSION\"" desktop/package.json > tmp.json && mv tmp.json desktop/package.json
+          jq --arg v "$VERSION" '.version = $v' desktop/package.json > tmp.json && mv tmp.json desktop/package.json
 
       # tauri-bundler notarizes only when APPLE_API_KEY_PATH points to the AuthKey .p8 on
       # disk; it does not consume APPLE_API_KEY_CONTENT. Materialize the key and export the
@@ -153,7 +172,7 @@ jobs:
 
       - name: Build and Publish Tauri Desktop App
         id: tauri
-        uses: tauri-apps/tauri-action@v0
+        uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # v0.6.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
@@ -173,11 +192,110 @@ jobs:
           args: --verbose
 
       # Machine-verifiable link between each published artifact and the source
-      # commit + workflow that built it (issue #26). Each matrix leg attests the
-      # bundles it produced: macOS the .dmg/.app.tar.gz, Windows the .msi/.exe.
-      # Attests artifact *origin* only — it says nothing about runtime behaviour.
-      - name: Attest build provenance
-        if: steps.tauri.outputs.artifactPaths != '' && steps.tauri.outputs.artifactPaths != '[]'
-        uses: actions/attest-build-provenance@v4
+      # commit + workflow that built it (issue #26). Attests artifact *origin*
+      # only -- it says nothing about runtime behaviour.
+      #
+      # The subject set must be the files that land on the release, not the
+      # build tree (issue #91). macOS and Windows are attested separately
+      # because `artifactPaths` describes them differently:
+      #
+      #   Windows: ["...\msi\*.msi", "...\nsis\*-setup.exe"] -- two files, and
+      #            both are uploaded verbatim. Pass them straight through.
+      #   macOS:   [".../dmg/*.dmg", ".../macos/tenby10.app"] -- the second is a
+      #            *directory*. attest-build-provenance walks it and attests the
+      #            Mach-O files inside, none of which is a release asset. The
+      #            asset that ships is the updater tarball tauri-action builds
+      #            from that bundle (uploaded as tenby10_<arch>.app.tar.gz) and
+      #            it is absent from artifactPaths entirely. Glob the two
+      #            published files instead. The *.app.tar.gz pattern matches the
+      #            tarball whether or not tauri-action renamed it on disk before
+      #            upload; either way the bytes -- and so the digest that
+      #            `gh attestation verify` looks up -- are the published ones.
+      - name: Attest build provenance (macOS)
+        if: runner.os == 'macOS' && steps.tauri.outputs.artifactPaths != '' && steps.tauri.outputs.artifactPaths != '[]'
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: |
+            desktop/src-tauri/target/release/bundle/dmg/*.dmg
+            desktop/src-tauri/target/release/bundle/macos/*.app.tar.gz
+
+      - name: Attest build provenance (Windows)
+        if: runner.os == 'Windows' && steps.tauri.outputs.artifactPaths != '' && steps.tauri.outputs.artifactPaths != '[]'
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-path: ${{ join(fromJSON(steps.tauri.outputs.artifactPaths), ',') }}
+
+  # Downloads what the release actually serves and re-checks every asset with
+  # the same command a user would run. A build-side subject list can drift from
+  # the upload set without anyone noticing (that drift is issue #91); this job
+  # is the check that cannot drift, because its input is the release itself.
+  # Runs once, after both matrix legs have uploaded.
+  verify-attestations:
+    name: Verify Published Assets Are Attested
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      attestations: read
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      TAG: ${{ github.event.inputs.tag || github.ref_name }}
+    steps:
+      - name: Download every published asset
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p published
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --dir published --clobber
+          ls -l published
+
+      - name: Verify provenance for every published asset
+        shell: bash
+        run: |
+          set -uo pipefail
+          shopt -s nullglob
+          files=(published/*)
+
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "::error::Release $TAG has no assets to verify."
+            exit 1
+          fi
+
+          {
+            echo "## Provenance verification for \`$TAG\`"
+            echo ""
+            echo "| Asset | Attestation |"
+            echo "| --- | --- |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          failed=0
+          for f in "${files[@]}"; do
+            name="$(basename "$f")"
+            ok=0
+            # The attestation is written moments earlier in the publish job, so
+            # allow for indexing lag before calling it a genuine miss.
+            for attempt in 1 2 3; do
+              if gh attestation verify "$f" --repo "$GITHUB_REPOSITORY"; then
+                ok=1
+                break
+              fi
+              if [ "$attempt" -lt 3 ]; then
+                echo "No attestation for $name yet (attempt $attempt/3); retrying in 15s."
+                sleep 15
+              fi
+            done
+            if [ "$ok" -eq 1 ]; then
+              echo "VERIFIED: $name"
+              echo "| \`$name\` | verified |" >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "::error::$name is published without a valid build provenance attestation."
+              echo "| \`$name\` | **MISSING** |" >> "$GITHUB_STEP_SUMMARY"
+              failed=1
+            fi
+          done
+
+          if [ "$failed" -ne 0 ]; then
+            echo "::error::One or more published assets are not covered by a build provenance attestation."
+            exit 1
+          fi
+          echo "All ${#files[@]} published assets carry a valid attestation."


### PR DESCRIPTION
## TL;DR

- The macOS updater tarball users auto-install has **no provenance attestation**. Verified live: 3 of 4 `v0.5.0` assets return an attestation, `tenby10_aarch64.app.tar.gz` returns 404. Root cause is that `artifactPaths` hands the attest action the `.app` *directory*, so it attested 5 files nobody downloads and missed the one they do.
- Fixed by attesting the published macOS files directly, plus a **new `verify-attestations` job** that downloads the finished release and runs `gh attestation verify` on every asset, failing the run if any is uncovered. That job is the part that matters: it reads the release itself, so this cannot regress quietly again.
- Also: tag no longer reaches a shell as script text, and all six third-party actions are pinned to full SHAs (frozen at today's resolution, nothing upgraded).
- **Judgement call to overrule if you disagree:** the version sync now *hard-fails* on a tag that doesn't yield `MAJOR.MINOR.PATCH`. `v1.2` used to proceed and die later in the MSI build; now it stops immediately. Windows is deliberately left on its existing code path.

closes #92
closes #91

## Context

Everything here is in `.github/workflows/`. No `daemon/`, `desktop/`, `AUDIT.md` or `README.md` changes.

**Provenance gap (#91).** Confirmed against run `32350868925` before changing anything. The macOS leg logged `Attestation created for 6 subjects` while Windows logged 2. The macOS `subject-path` was:

```
.../bundle/dmg/tenby10_0.5.0_aarch64.dmg     <- a file, and a published asset
.../bundle/macos/tenby10.app                 <- a DIRECTORY, not a published asset
```

The action walked the directory and attested the 5 Mach-O files inside it. But the log's `Found artifacts:` line lists only the dmg and the `.app`, while `Uploading tenby10_aarch64.app.tar.gz...` happens separately: the updater tarball is uploaded but never appears in `artifactPaths`, so it was never a subject. Confirmed end-to-end against the live API, no downloads needed:

| `v0.5.0` asset | `GET /attestations/{digest}` |
| --- | --- |
| `tenby10_0.5.0_aarch64.dmg` | attested |
| `tenby10_0.5.0_x64-setup.exe` | attested |
| `tenby10_0.5.0_x64_en-US.msi` | attested |
| `tenby10_aarch64.app.tar.gz` | **404** |

**Tag reaching a shell (#92).** `REF="${{ ... }}"` inside `run:` makes the ref's characters part of the script, in the job holding the signing identity. `pr-lint.yml` already does this correctly via `env:`.

**Moving action refs (#92).** `@v0`, `@stable`, `@v2`, `@v4` all resolve to whatever the upstream owner points them at.

## Changes

**1. Tag through `env:`.** Read as `"$REF"`, validated against `^[0-9]+\.[0-9]+\.[0-9]+$`, then passed to `jq` with `--arg` instead of being interpolated into the jq program. `release.yml` was the only file with an expression inside a shell body; `notarize-check.yml` was already clean.

**2. Six actions pinned to full SHAs.** Every SHA was resolved with `gh api repos/<owner>/<repo>/commits/<ref> -q .sha` and re-checked to confirm it resolves. Each is *exactly* what the old ref points at today, so this freezes current behaviour rather than upgrading:

| Action | Pin | Was |
| --- | --- | --- |
| `actions/checkout` | `11d5960` | `@v4` = v4.4.0 |
| `actions/setup-node` | `49933ea` | `@v4` = v4.4.0 |
| `Swatinem/rust-cache` | `6323deb` | `@v2` = v2.9.2 |
| `dtolnay/rust-toolchain` | `4360b52` | `@stable` branch head |
| `tauri-apps/tauri-action` | `84b9d35` | `@v0` = v0.6.2 |
| `actions/attest-build-provenance` | `4d10147` | `@v4` = v4.2.2 |

`dtolnay/rust-toolchain` is pinned to its `stable` *branch* head. That branch's `action.yml` defaults `toolchain: stable`, so this freezes the action code, not the Rust release, and rustup still resolves stable at run time.

**3. Attestation split by OS.** Windows keeps `join(fromJSON(steps.tauri.outputs.artifactPaths), ',')` verbatim, unchanged, because both its paths are real files that match the uploaded assets. macOS instead globs the two files that actually ship:

```yaml
subject-path: |
  desktop/src-tauri/target/release/bundle/dmg/*.dmg
  desktop/src-tauri/target/release/bundle/macos/*.app.tar.gz
```

Splitting per-OS avoids putting a macOS-only glob on the Windows leg, where a non-matching pattern could fail the job. The `*.app.tar.gz` pattern matches the tarball whether or not `tauri-action` renames it on disk before upload, since either way the bytes, and therefore the digest `gh attestation verify` looks up, are the published ones.

**4. New `verify-attestations` job.** `needs: publish`, so it runs once after both legs. Downloads the finished release with `gh release download` and runs `gh attestation verify <asset> --repo $GITHUB_REPOSITORY` over every asset, with 3 attempts to absorb indexing lag. Fails the run if any asset is uncovered, and fails if the release has zero assets so an empty download can't pass by default. Writes a per-asset pass/fail table to the step summary.

## What I could not verify

A release run cannot be dry-run, so no part of this executed on real CI. What I did instead:

- Both files parse as YAML; every `run:` body extracted and checked with `bash -n`; confirmed zero `${{ }}` remain inside any shell body.
- The version-sync script was executed locally against real `tauri.conf.json` / `package.json` copies. `v0.5.0`, `v0.1.3-beta`, `v0.0.0-dev` produce the same versions as before; `v1.2` and metacharacter-bearing refs are rejected with no substitution performed.
- The verification loop was executed locally against a stubbed `gh`: passes on 4 good assets, fails with a per-asset error on an unattested tarball (the exact `v0.5.0` situation), fails on an empty release.
- `actionlint` is not installed here, so no workflow-schema lint ran.

**Unverified and worth knowing:** the macOS glob paths are taken from the `v0.5.0` log, so they are right for a build with no `--target` flag. If a future change adds an explicit target triple, the bundle moves under `target/<triple>/release/` and the glob stops matching. That fails the attest step loudly rather than under-attesting, and `verify-attestations` would catch it regardless. I also could not confirm on real hardware that `gh attestation verify` finds the tarball, only that the digest logic is sound; the first release after this merge is the real test.

## Follow-up, not in this PR

`ci.yml` still uses `actions/checkout@v4` and `Swatinem/rust-cache@v2` unpinned (8 references). It holds no signing secrets, so it is a lower priority than the release path, and I kept this PR to the two workflows named in #92. Worth its own issue.
