### PR TITLE
fix(daemon): gate daily work notes on the AI engine switch

### DIFF
--- a/daemon/src/daemon.rs
+++ b/daemon/src/daemon.rs
@@ -445,23 +445,82 @@ pub fn start_daemon_loop(db: Arc<Database>, state: Arc<TelemetryState>) {
 /// user's own API budget summarizing history nobody asked for.
 const SUMMARY_LOOKBACK_DAYS: i64 = 7;
 
+/// Whether a daily work note should be written at all, as one decision (#96).
+///
+/// Three conditions, all required:
+/// - **The AI engine is on.** Writing a note *is* the AI running: it sends the day's
+///   window titles to the user's own provider. A switch presented as the AI has to
+///   govern that, or "AI off" is not off. Before #96 only slot scoring was gated
+///   here, so an install set to `static` still talked to the network once a day —
+///   surprising in the one direction that matters, data leaving the machine.
+/// - **Notes are not opted out** (`disable_work_summaries`, ADR 0019 §2).
+/// - **An AI is actually configured**, which the caller establishes by asking
+///   [`crate::llm::get_llm_provider`] for one.
+///
+/// Pure so the rule is testable without a config file on disk, a database, or a
+/// provider on the network — the same shape as `debug_http_enabled_from` in
+/// [`crate::env`]. `has_provider` is passed in rather than derived because deriving
+/// it needs the key and URL validation this function deliberately does not do.
+///
+/// Limit worth knowing: `work_notes_enabled` in `desktop/src-tauri/src/lib.rs`
+/// answers the same question for the dashboard's empty state and still carries its
+/// own copy of the rule. It should call this instead; until it does, the two can
+/// disagree about an install whose engine is `static`.
+pub fn work_notes_enabled(
+    engine_mode: &str,
+    disable_work_summaries: bool,
+    has_provider: bool,
+) -> bool {
+    engine_mode == "llm" && !disable_work_summaries && has_provider
+}
+
+/// Say once per run — not once per 60-second loop — that an install which used to
+/// receive work notes no longer does (#96).
+///
+/// Honest about its reach: this is a log line, so it is only seen by someone reading
+/// the daemon's output. The dashboard carries the same message where the note would
+/// have been, which is where a user actually notices the absence.
+fn warn_work_notes_gated_by_engine(engine_mode: &str) {
+    static WARNED: std::sync::Once = std::sync::Once::new();
+    WARNED.call_once(|| {
+        println!(
+            "[Summary] An AI is configured and daily work notes are switched on, but the AI \
+             engine is set to \"{engine_mode}\" — so no note will be written, and no window \
+             title is sent to your provider. Turn the AI Auditor on in Settings to resume \
+             notes. Hours, categories and rules are unaffected."
+        );
+    });
+}
+
 /// Write the daily work note for any finished local day that doesn't have one yet
 /// (ADR 0019).
 ///
-/// Runs off the same 60-second loop as aggregation and requires nothing from the user:
-/// notes exist because their AI is configured, which is what the AI is for. A day is
-/// only summarized once it is over, and only once — so this is safe to call repeatedly.
+/// Runs off the same 60-second loop as aggregation and requires nothing from the user
+/// beyond switching the AI on: notes exist because their AI is running, which is what
+/// the AI is for. A day is only summarized once it is over, and only once — so this is
+/// safe to call repeatedly.
 pub fn generate_pending_summaries(db: &Database) {
     let mut config_path = crate::env::get_app_home();
     config_path.push("config.json");
     let config = crate::config::load_config(config_path).unwrap_or_default();
 
-    if config.disable_work_summaries {
-        return;
-    }
-    let Some(provider) = crate::llm::get_llm_provider(&config) else {
-        // No AI configured: hours, categories and rules still work, there is just no
-        // note. Nothing to warn about on every loop.
+    // The provider lookup comes first because "is an AI configured" is part of the
+    // decision, not a step after it. It builds a client; it sends nothing.
+    let provider = crate::llm::get_llm_provider(&config);
+    let has_provider = provider.is_some();
+    let notes_on = work_notes_enabled(
+        &config.engine_mode,
+        config.disable_work_summaries,
+        has_provider,
+    );
+    let Some(provider) = provider.filter(|_| notes_on) else {
+        // No AI configured, or notes opted out: hours, categories and rules still work,
+        // there is just no note, and neither case is worth a line every loop. The one
+        // case worth saying out loud is what #96 changes — a configured AI, notes on,
+        // and the engine off — where this install used to get notes and now will not.
+        if has_provider && !config.disable_work_summaries {
+            warn_work_notes_gated_by_engine(&config.engine_mode);
+        }
         return;
     };
 
@@ -1673,5 +1732,39 @@ mod tests {
         let buf = state.keystroke_intervals.lock().unwrap();
         assert_eq!(buf.len(), KEY_INTERVAL_WINDOW, "capped to the window size");
         assert_eq!(*buf.first().unwrap(), 50, "oldest samples dropped");
+    }
+
+    #[test]
+    fn test_work_notes_follow_the_ai_engine_switch() {
+        // #96, stated as the scenario it came from: a provider and key are configured,
+        // so the note path *would* have called out to the network. Whether it does is
+        // now the engine switch's decision.
+        let mut config = AgentConfig::default();
+        config.llm_provider = "openai".to_string();
+        config.llm_api_key = "test_key".to_string();
+        assert!(
+            crate::llm::get_llm_provider(&config).is_some(),
+            "the scenario requires an AI that would actually have been called"
+        );
+        let has_provider = true;
+
+        assert!(
+            work_notes_enabled("llm", false, has_provider),
+            "engine on, notes on, AI configured -> the note is written"
+        );
+        assert!(
+            !work_notes_enabled("static", false, has_provider),
+            "engine off -> no note and no request, however well configured the AI is"
+        );
+
+        // The two pre-existing gates still hold on their own terms.
+        assert!(
+            !work_notes_enabled("llm", true, has_provider),
+            "an explicit opt-out still wins with the engine on"
+        );
+        assert!(
+            !work_notes_enabled("llm", false, false),
+            "no AI configured -> nothing to call"
+        );
     }
 }

--- a/desktop/src/dashboard.js
+++ b/desktop/src/dashboard.js
@@ -34,6 +34,12 @@ function goHome() {
         // an AI configured the log still shows hours, categories and rules.
         let workNotes = {};
         let workNotesEnabled = false;
+        // Whether the AI engine itself is on. Since #96 the engine switch decides
+        // whether the AI runs at all, notes included, so "AI configured" is no longer
+        // enough to know a note is coming. Tracked separately because the
+        // work_notes_enabled command does not account for the engine yet; when it
+        // does, this can go and workNotesEnabled alone will be right again.
+        let aiEngineOn = false;
 
         function dateKeyOf(unixSeconds) {
             const d = new Date(unixSeconds * 1000);
@@ -46,6 +52,10 @@ function goHome() {
         async function fetchWorkNotes() {
             try {
                 workNotesEnabled = await invoke('work_notes_enabled');
+                // Only the engine mode is read here; the rest of the config is dropped
+                // on the next line and nothing else is kept.
+                const engineMode = (await invoke('get_agent_config')).engine_mode;
+                aiEngineOn = engineMode === 'llm';
                 // One fetch covers every view; the volume is one row per worked day.
                 const notes = await invoke('dashboard_work_notes', { from: 0, to: 4102444800 });
                 workNotes = {};
@@ -82,6 +92,17 @@ function goHome() {
                     <div class="work-note-card work-note-empty">
                         <p class="work-note-text">Connect your own AI in Settings and tenby10 writes a short note of each day's work, in plain words.</p>
                         <span class="work-note-meta">Without it, your log shows hours and categories only.</span>
+                    </div>
+                `;
+            }
+            // An AI is connected and notes are switched on, but the engine is off, so
+            // no note is coming (#96). Anyone who was getting notes with the engine on
+            // static stops after this change; a blank space would leave them guessing.
+            if (!aiEngineOn) {
+                return `
+                    <div class="work-note-card work-note-empty">
+                        <p class="work-note-text">Your AI is connected, but the AI Auditor is switched off, so no note is written for this day.</p>
+                        <span class="work-note-meta">Turn the AI Auditor on in Settings to start notes again. Your hours and categories are unaffected.</span>
                     </div>
                 `;
             }

--- a/desktop/src/index.html
+++ b/desktop/src/index.html
@@ -136,6 +136,19 @@
             </label>
           </div>
           <p class="desc">Audit slot focus using an LLM. Bypasses LLM during fully idle slots.</p>
+          <!-- One line per state, never both (#96). On: say how far the switch reaches,
+               since the work-note switch below is inside its scope. Off: the work-note
+               switch is hidden with the rest of #llm-fields, so this stands in for it
+               rather than leaving the off state to be inferred. -->
+          <p id="engine-scope-note" class="desc" style="display: none;">
+            This switch governs everything that calls your AI, including the daily work
+            note below.
+          </p>
+          <p id="engine-off-notice" class="desc" style="display: none;">
+            The AI Auditor is off, so nothing is sent to your AI provider. That includes
+            the daily work note, which is not written while this switch is off. Your
+            hours, categories and rules keep working exactly as they do now.
+          </p>
 
           <!-- Dynamic LLM Fields -->
           <div id="llm-fields" style="display: none; flex-direction: column; gap: 1rem;">

--- a/desktop/src/main.js
+++ b/desktop/src/main.js
@@ -154,6 +154,17 @@ function toggleLlmFields(isEnabled) {
   if (llmFields) {
     llmFields.style.display = isEnabled ? "flex" : "none";
   }
+  // The daily-work-note switch is inside #llm-fields, so turning the engine off takes
+  // it off screen along with the fields. Since the engine now decides whether notes
+  // are written at all (#96), the off state has to say so in the switch's place.
+  const engineScopeNote = document.getElementById("engine-scope-note");
+  if (engineScopeNote) {
+    engineScopeNote.style.display = isEnabled ? "block" : "none";
+  }
+  const engineOffNotice = document.getElementById("engine-off-notice");
+  if (engineOffNotice) {
+    engineOffNotice.style.display = isEnabled ? "none" : "block";
+  }
 }
 
 if (aiEngineToggle) {


### PR DESCRIPTION
## TL;DR

**This changes behaviour.** Daily work notes now require the AI engine to be on, not just an AI to be configured. Anyone running with the engine on `static` and a provider configured is getting notes today and will stop getting them after this merges. That is the point: writing a note sends the day's window titles to their provider, and a switch labelled as the AI should decide whether the AI runs.

If you read it the other way — notes and scoring are separate features, and the fix is only that the UI never said so — close this PR and take option 2 instead. See the last section; you should not need to reopen the issue to decide.

## Context

`generate_pending_summaries` gated only on `disable_work_summaries`. The only `engine_mode` check in `daemon.rs` guarded slot scoring. So an install set to `static`, where the settings pane shows the AI switched off and hides every AI field, still called out to the user's provider once a day with the day's activity digest.

Two things pushed me to option 1 as the default reading:

1. **The UI already treats notes as part of the engine.** The work-note switch and its prompt live inside `#llm-fields`, which is hidden whenever the engine is off. A user with the engine on `static` cannot see the note switch, cannot turn it off, and has no indication anywhere that notes are still being written. Gating on `engine_mode` makes the code agree with what the UI has been saying all along, and it leaves no dead control behind.
2. **ADR 0019 §1 says "When BYOK AI is enabled, the daemon generates one short work summary per day."** The engine switch is what enables BYOK AI in the UI. AUDIT.md currently reads that clause as "connecting an AI is enough, by design" — defensible, but it is the weaker of the two readings of the ADR's own words.

Against option 1, honestly: ADR 0019's binding principle is "setup once, then invisible", and this adds a second thing you must have on for notes to appear. And the change is retroactive on installs that are working fine today.

## Changes

**`daemon/src/daemon.rs`** (confined to `generate_pending_summaries` and above it; nothing near the auditor path at ~line 790)

- New pure `work_notes_enabled(engine_mode, disable_work_summaries, has_provider)` holding the whole rule in one place, in the `debug_http_enabled_from` style from `env.rs`, with a test proving notes generate with engine `llm` + a provider configured and do not with engine `static`.
- `generate_pending_summaries` calls it instead of carrying the rule inline.
- `warn_work_notes_gated_by_engine`: one log line, once per run (`std::sync::Once`, not once per 60-second loop), fired only in the case this PR changes — a configured AI, notes not opted out, engine off. Its limit is in the doc comment: a log line is only seen by someone reading the daemon's output, which is why the dashboard also carries the message.

**`desktop/src/index.html` + `desktop/src/main.js`** (small, localised — one function, `toggleLlmFields`, so it should not collide with the API-key rework in the settings form)

- Two mutually exclusive lines under the AI Auditor switch, driven by `toggleLlmFields`. Engine on: "This switch governs everything that calls your AI, including the daily work note below." Engine off: "The AI Auditor is off, so nothing is sent to your AI provider. That includes the daily work note, which is not written while this switch is off. Your hours, categories and rules keep working exactly as they do now."
- No control was disabled, because there is none to disable: the work-note switch is inside `#llm-fields` and goes off screen with the engine. The off-state line stands in its place.

**`desktop/src/dashboard.js`**

- `renderWorkNote` gains a third state: AI connected, notes on, engine off. It says why the day has no note and how to get them back, instead of rendering an empty space. Without it this change is completely silent for exactly the users it affects.
- This needs the engine mode, which the dashboard did not have, so `fetchWorkNotes` reads `engine_mode` off `get_agent_config` (only that field, nothing retained). See the known gap below.

## Known gap, deliberately left

`work_notes_enabled` in `desktop/src-tauri/src/lib.rs:495` answers the same question for the dashboard and still carries its own copy of the old rule, so it reports "notes on" for a `static` install that will never get one. `desktop/src-tauri/` belongs to another thread right now, so I did not touch it; the dashboard reads `engine_mode` separately to stay correct in the meantime. The follow-up is one line:

```rust
Ok(daemon::daemon::work_notes_enabled(
    &config.engine_mode,
    config.disable_work_summaries,
    daemon::llm::get_llm_provider(&config).is_some(),
))
```

after which the extra `get_agent_config` call in `dashboard.js` can go.

`AUDIT.md` §2 and `README.md` describe the current behaviour accurately and are untouched on purpose (a sibling thread is in AUDIT.md). Both need a follow-up if this lands: the egress inventory's "Daily work note" row still says it is **not** gated on `engine_mode`.

## Verification

`cargo fmt -- --check`, `cargo clippy -- -D warnings`, `cargo test` all pass in `daemon/` (123 tests) and `desktop/src-tauri/` (8 tests).

The UI states were checked by rendering `index.html` and `dashboard.html` against a stubbed IPC bridge: engine off shows the off-state line with the LLM fields hidden; engine on shows the scope line with the fields and the work-note switch; and `renderWorkNote` returns the connect-your-AI invitation with no provider, the new engine-off card with a provider and the engine on `static`, and nothing at all with the engine on `llm` and a note simply not written yet.

To see it in the app: Settings → AI Auditor, toggle the switch and watch the line under the header change. Then, with a provider and key saved and the engine off, open the dashboard on any past day with logged time — the note card now explains itself instead of being blank.

## If you prefer option 2

Close this PR. Option 2 keeps notes running whenever an AI is configured and fixes only the disclosure, which means:

- Revert the `daemon.rs` gate and the `warn_work_notes_gated_by_engine` line. `work_notes_enabled` can stay as the shared predicate with the `engine_mode` argument dropped.
- The settings copy has to move and change sense. The off-state line must stop saying "nothing is sent to your AI provider" and instead say the opposite: something like "Slot scoring is off. Your daily work note is still written once a day, which sends that day's window titles to your provider. Turn notes off below." — and the work-note switch has to come out of `#llm-fields` so it is still reachable with the engine off, which is a real markup move rather than a copy tweak.
- The dashboard change is unnecessary; drop it and the extra `get_agent_config` call with it.
- `AUDIT.md`'s current wording stays correct and needs no follow-up.

My read: option 1. The deciding fact is not the ADR, it is that the UI already hides the note switch when the engine is off — so under option 2 we would be shipping a feature that sends data to a third party with its only off-switch hidden behind a different switch that says it is off. Option 2's disclosure work is also strictly larger than option 1's, because it has to surface a control that is currently hidden rather than explain an absence.

closes #96
