### PR TITLE
ci: add an advisory gate, pin rdev, and unblock fresh clones

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,7 +1,58 @@
 #!/bin/bash
 set -e
 
+cd "$(git rev-parse --show-toplevel)"
+
 echo "=== Running Pre-Commit Hooks ==="
+
+# 0. Fresh-clone guard (issue #93).
+#
+# desktop/src-tauri/icons/ is gitignored and staged by scripts/dev.sh or
+# scripts/prod.sh. In a fresh clone or a new worktree it does not exist, and the
+# desktop clippy step below then dies on missing include_bytes! targets with a
+# compile error that names a path nobody has ever seen in the repo.
+#
+# We fail here instead of staging the icons ourselves, on purpose:
+#   * a commit hook must not mutate the working tree behind the author's back,
+#     and staging would mean picking icons_dev or icons_prod — overwriting a
+#     dev-staged icons/ with prod branding mid-commit is exactly the kind of
+#     surprise that costs an hour to notice;
+#   * the advice people were missing ("run scripts/dev.sh") does not actually
+#     work as an instruction, because that script stages the icons *and then*
+#     launches the app and blocks. There was no staging-only command to point
+#     at, so this prints the two lines that do it.
+REQUIRED_ICONS=(
+  desktop/src-tauri/icons/32x32.png
+  desktop/src-tauri/icons/32x32_paused.png
+  desktop/src-tauri/icons/128x128.png
+  desktop/src-tauri/icons/128x128@2x.png
+  desktop/src-tauri/icons/icon.icns
+  desktop/src-tauri/icons/icon.ico
+)
+MISSING_ICONS=()
+for icon in "${REQUIRED_ICONS[@]}"; do
+  [ -f "$icon" ] || MISSING_ICONS+=("$icon")
+done
+
+if [ ${#MISSING_ICONS[@]} -ne 0 ]; then
+  echo ""
+  echo "ERROR: desktop/src-tauri/icons/ is not staged, so the desktop crate cannot build."
+  echo ""
+  echo "That directory is gitignored and populated from icons_prod/ or icons_dev/."
+  echo "Missing:"
+  for icon in "${MISSING_ICONS[@]}"; do
+    echo "  - $icon"
+  done
+  echo ""
+  echo "Stage the production icons (what CI uses) by running this from the repo root:"
+  echo ""
+  echo "  mkdir -p desktop/src-tauri/icons && cp -r desktop/src-tauri/icons_prod/. desktop/src-tauri/icons/"
+  echo ""
+  echo "Then commit again. To run the app locally instead, scripts/dev.sh and"
+  echo "scripts/prod.sh stage the icons for you before launching."
+  echo ""
+  exit 1
+fi
 
 # 1. Daemon Checks
 echo "Checking daemon formatting..."
@@ -27,4 +78,3 @@ cargo test
 
 cd ../..
 echo "=== All checks passed! ==="
-

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,199 @@
+name: Advisories
+
+# Supply-chain gate for issue #93.
+#
+# Dependabot already bumps versions weekly, but nothing failed the build on a
+# known-vulnerable lockfile, so CI went green on one. This job is that gate. It
+# audits BOTH workspaces (daemon/Cargo.lock and desktop/src-tauri/Cargo.lock)
+# against the RustSec advisory database. It only reads lockfiles: no toolchain
+# build, no staged icons, no npm install.
+#
+# ── Blocking policy, stated up front ────────────────────────────────────────
+# A brand-new upstream advisory WILL fail otherwise-unrelated PRs. That is the
+# deliberate choice, because:
+#   * the fix is nearly always one line (`cargo update -p <crate>`);
+#   * this repo ships a signed desktop agent that installs global keyboard and
+#     mouse hooks, so a vulnerable dependency reaching a release costs far more
+#     than a temporarily blocked PR;
+#   * the nightly `schedule:` run below normally catches a new advisory against
+#     `main` before it ever lands on somebody's branch.
+# The only escape hatch is the IGNORED_IDS list in the audit step: an explicit,
+# commented, code-reviewed entry. There is no silent bypass and no soft-fail on
+# a *found* advisory. The one soft-fail in this workflow is documented inline
+# and can only fire when the advisory database itself could not be downloaded.
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  # Advisories arrive by calendar, not by commit. Catch them against main.
+  schedule:
+    - cron: "27 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: advisories-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  # Pinned so the gate's behaviour does not change under us.
+  CARGO_AUDIT_VERSION: "0.22.2"
+  # Scratch clone of RustSec/advisory-db. Nothing in this job writes to the
+  # repo, so it is only ever untracked scratch space.
+  ADVISORY_DB: ${{ github.workspace }}/.advisory-db
+
+jobs:
+  advisories:
+    name: Advisory gate
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Cache cargo-audit
+      uses: actions/cache@v4
+      with:
+        path: ~/.cargo/bin/cargo-audit
+        key: cargo-audit-${{ runner.os }}-${{ env.CARGO_AUDIT_VERSION }}
+
+    - name: Install cargo-audit
+      run: |
+        if [ -x "$HOME/.cargo/bin/cargo-audit" ] \
+           && cargo audit --version | grep -qF "$CARGO_AUDIT_VERSION"; then
+          echo "cargo-audit $CARGO_AUDIT_VERSION restored from cache."
+          exit 0
+        fi
+        cargo install cargo-audit --version "$CARGO_AUDIT_VERSION" --locked
+
+    - name: Fetch RustSec advisory database
+      id: db
+      run: |
+        # Cloned fresh on every run and never cached: a stale advisory DB is a
+        # gate that quietly stops catching things. Retried, because a single
+        # failed clone of a third-party repo must not fail somebody's PR.
+        for attempt in 1 2 3; do
+          rm -rf "$ADVISORY_DB"
+          if git clone --depth 1 --quiet \
+               https://github.com/RustSec/advisory-db.git "$ADVISORY_DB"; then
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "advisory-db clone attempt $attempt/3 failed"
+          sleep $((attempt * 10))
+        done
+        echo "ok=false" >> "$GITHUB_OUTPUT"
+
+    # THE ONE SOFT-FAIL. Reachable only when the advisory database could not be
+    # cloned three times in a row, i.e. GitHub was unreachable. It cannot mask a
+    # found advisory, because in this branch no audit ran at all — and it says
+    # so loudly, in both the annotation and the job summary.
+    - name: Advisory database unavailable (soft-fail, announced)
+      if: steps.db.outputs.ok != 'true'
+      run: |
+        echo "::warning title=Advisory gate skipped::Could not clone the RustSec advisory database after 3 attempts. The lockfiles were NOT audited on this run. Re-run the job."
+        {
+          echo "### :warning: Advisory gate SKIPPED — nothing was audited"
+          echo
+          echo "Cloning \`RustSec/advisory-db\` failed three times, so \`cargo audit\`"
+          echo "never ran. This is the only condition under which this job passes"
+          echo "without auditing, and it cannot hide a found advisory: no audit was"
+          echo "performed at all."
+          echo
+          echo "**Re-run this job** once GitHub is reachable again."
+        } >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Audit both workspaces
+      if: steps.db.outputs.ok == 'true'
+      run: |
+        # ── Ignore list ─────────────────────────────────────────────────────
+        # Every entry needs a written reason and is reviewed like any other
+        # diff. cargo-audit prints each ignored advisory in its own report, and
+        # the list is echoed into the job summary below, so nothing here is
+        # suppressed silently.
+        #
+        # RUSTSEC-2024-0429 — glib 0.18.5, unsound `VariantStrIter` iterator
+        #   impls. Reached only through tauri -> tray-icon -> libappindicator
+        #   -> gtk, which is the Linux GTK3 backend. Both
+        #       cargo tree -i glib --target aarch64-apple-darwin
+        #       cargo tree -i glib --target x86_64-pc-windows-msvc
+        #   print nothing, so this crate is not compiled into anything we ship.
+        #   The gtk-rs GTK3 bindings are retired: there is no fixed release to
+        #   upgrade to, so denying it would be permanently unactionable.
+        IGNORED_IDS=(
+          RUSTSEC-2024-0429
+        )
+
+        IGNORE_ARGS=()
+        for id in "${IGNORED_IDS[@]}"; do
+          IGNORE_ARGS+=( --ignore "$id" )
+        done
+
+        {
+          echo "### Advisory gate"
+          echo
+          echo "Explicitly ignored advisories (see the comment in \`.github/workflows/audit.yml\`):"
+          echo
+          for id in "${IGNORED_IDS[@]}"; do
+            echo "- \`$id\`"
+          done
+          echo
+          echo "\`unmaintained\` advisories are reported but do not block — see the"
+          echo "non-blocking report below for the current list."
+        } >> "$GITHUB_STEP_SUMMARY"
+
+        status=0
+        for lock in daemon/Cargo.lock desktop/src-tauri/Cargo.lock; do
+          echo "::group::cargo audit $lock"
+          # --no-fetch + --db: hermetic, the DB was cloned in the step above.
+          # --no-yanked: yanked detection needs a live crates.io index fetch,
+          #   which is the flakiest thing cargo-audit does. It is kept out of
+          #   the blocking gate and runs in the non-blocking report instead.
+          # --deny unsound: unsoundness is a real defect class (this issue's
+          #   RUSTSEC-2026-0221 was one) and cargo-audit does not fail on it by
+          #   default.
+          # `unmaintained` is deliberately NOT denied: by definition there is no
+          #   fixed version to move to, so a blocking gate on it could only be
+          #   satisfied by ignoring it. It stays visible in every report.
+          cargo audit \
+            --no-fetch --db "$ADVISORY_DB" \
+            --no-yanked \
+            --deny unsound \
+            "${IGNORE_ARGS[@]}" \
+            --file "$lock" || status=1
+          echo "::endgroup::"
+        done
+
+        if [ "$status" -ne 0 ]; then
+          echo "::error title=Advisory found::cargo audit failed. Fix with a targeted 'cargo update -p <crate>' in the affected workspace, or add an explicitly justified entry to IGNORED_IDS in .github/workflows/audit.yml."
+        fi
+        exit $status
+
+    - name: Non-blocking advisory report
+      if: always() && steps.db.outputs.ok == 'true'
+      continue-on-error: true
+      run: |
+        # Full, unfiltered picture — unmaintained crates and yanked versions
+        # included. This step never fails the build; it exists so the things the
+        # gate deliberately does not block on stay in front of us.
+        {
+          echo "### Non-blocking advisory report"
+          echo
+          echo "Full \`cargo audit\` output, nothing ignored or denied. Informational only."
+          for lock in daemon/Cargo.lock desktop/src-tauri/Cargo.lock; do
+            echo
+            echo "<details><summary><code>$lock</code></summary>"
+            echo
+            echo '```'
+            # --color never: this output is embedded in markdown, not a terminal.
+            cargo audit --color never --no-fetch --db "$ADVISORY_DB" \
+              --file "$lock" 2>&1 || true
+            echo '```'
+            echo
+            echo "</details>"
+          done
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [ "main" ]
 
+# This workflow only reads the tree: fmt, clippy and tests. It writes nothing
+# back to the repo, so it does not need the repo's default token grant.
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
+# Reads the PR title and body from the event payload and nothing else. It posts
+# no comments, sets no statuses and pushes no commits.
+permissions:
+  contents: read
+
 jobs:
   pr-lint:
     name: PR Title and Body Lint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,23 @@ Releases are tag-driven and fully automated:
 
 ## 4. Local Development & Testing
 
+### First, once per clone: stage the icons
+
+`desktop/src-tauri/icons/` is gitignored. The desktop crate `include_bytes!`s several
+files out of it, so in a fresh clone (or a fresh `git worktree`) the desktop build fails
+with a confusing "no such file" compile error until the directory is populated.
+
+Run this once from the repo root:
+
+```bash
+mkdir -p desktop/src-tauri/icons && cp -r desktop/src-tauri/icons_prod/. desktop/src-tauri/icons/
+```
+
+`scripts/dev.sh` and `scripts/prod.sh` also stage the icons, but they launch the app
+straight afterwards, so they are not a substitute if you only want to build or commit.
+The `pre-commit` hook checks for the icons first and prints the command above if they
+are missing, rather than letting you hit the compile error.
+
 Before committing your code, please verify that your changes build and pass all local tests.
 
 ### Telemetry Daemon (Rust)
@@ -99,3 +116,32 @@ npm install
 # Run the Tauri app tests
 cd src-tauri && cargo test
 ```
+
+### Dependency advisories
+
+The `Advisories` workflow runs `cargo audit` over both lockfiles on every PR, nightly
+against `main`, and fails the build on a vulnerability or an unsoundness advisory. To
+reproduce it locally:
+
+```bash
+cargo install cargo-audit --locked
+cargo audit --file daemon/Cargo.lock
+cargo audit --file desktop/src-tauri/Cargo.lock
+```
+
+Fix a hit with a **targeted** update in the affected workspace, e.g. `cargo update -p h2`.
+Avoid a bare `cargo update`: it re-resolves hundreds of unrelated crates and makes the
+lockfile diff unreviewable.
+
+Two things the gate deliberately does not block on, both reported on every run and never
+suppressed silently:
+
+* `unmaintained` advisories, which by definition have no fixed version to move to. Ours
+  are the Linux-only GTK3 stack that Tauri pulls in and which never compiles into a macOS
+  or Windows artifact.
+* Anything on the explicit ignore list in `.github/workflows/audit.yml`. Each entry
+  carries a written reason and is reviewed like any other diff.
+
+The `rdev` dependency is pinned to an exact commit in `daemon/Cargo.toml`. It installs the
+global keyboard and mouse hooks and lives on a personal fork rather than crates.io, so
+changing that SHA is a security-relevant change and belongs in its own PR.

--- a/daemon/Cargo.lock
+++ b/daemon/Cargo.lock
@@ -745,7 +745,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -953,9 +953,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "9f877e75f39e9827ec50a572dd592684ac28c029578726c85f1b2aa6ab807449"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1823,9 +1823,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.30.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -1956,7 +1956,7 @@ checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 [[package]]
 name = "rdev"
 version = "0.5.0-2"
-source = "git+https://github.com/fufesou/rdev#23e24dd6b35452a495dae0ae6d99395e9755ab0f"
+source = "git+https://github.com/fufesou/rdev?rev=23e24dd6b35452a495dae0ae6d99395e9755ab0f#23e24dd6b35452a495dae0ae6d99395e9755ab0f"
 dependencies = [
  "cocoa",
  "core-foundation 0.9.4",
@@ -2140,7 +2140,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2197,7 +2197,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2457,7 +2457,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2593,7 +2593,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2982,7 +2982,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3316,11 +3316,11 @@ dependencies = [
 
 [[package]]
 name = "xcb"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4c580d8205abb0a5cf4eb7e927bd664e425b6c3263f9c5310583da96970cf6"
+checksum = "a6c2ad15e0e922856ee89afe862b8992334bbe7953adad56cd1199358cb30566"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.13.0",
  "libc",
  "quick-xml",
 ]

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -5,7 +5,13 @@ edition = "2024"
 
 [dependencies]
 rusqlite = { version = "0.40", features = ["bundled"] }
-rdev = { git = "https://github.com/fufesou/rdev" }
+# rdev installs the global keyboard/mouse hooks, so it is the single most
+# security-sensitive dependency in the tree: a personal fork, not on crates.io.
+# It MUST stay pinned to an exact commit. Without `rev` the manifest resolves to
+# whatever that fork's default branch holds whenever a lockfile is regenerated,
+# and the two workspaces had already drifted apart on exactly that (issue #93).
+# Changing this SHA is a review-worthy change on its own; do not bump it casually.
+rdev = { git = "https://github.com/fufesou/rdev", rev = "23e24dd6b35452a495dae0ae6d99395e9755ab0f" }
 chrono = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -1182,7 +1182,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1443,16 +1443,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -1988,9 +1987,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "9f877e75f39e9827ec50a572dd592684ac28c029578726c85f1b2aa6ab807449"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2906,7 +2905,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3444,13 +3443,13 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plist"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml 0.39.4",
+ "quick-xml",
  "serde",
  "time",
 ]
@@ -3605,18 +3604,9 @@ checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "quick-xml"
-version = "0.30.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.39.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -3753,7 +3743,7 @@ checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 [[package]]
 name = "rdev"
 version = "0.5.0-2"
-source = "git+https://github.com/fufesou/rdev#871bf1c856d6a30af2f56ab8848396a025140855"
+source = "git+https://github.com/fufesou/rdev?rev=23e24dd6b35452a495dae0ae6d99395e9755ab0f#23e24dd6b35452a495dae0ae6d99395e9755ab0f"
 dependencies = [
  "cocoa",
  "core-foundation 0.9.4",
@@ -3994,7 +3984,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4051,7 +4041,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4506,7 +4496,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5089,7 +5079,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5481,7 +5471,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5516,7 +5506,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5934,7 +5924,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6545,13 +6535,13 @@ dependencies = [
 
 [[package]]
 name = "xcb"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4c580d8205abb0a5cf4eb7e927bd664e425b6c3263f9c5310583da96970cf6"
+checksum = "a6c2ad15e0e922856ee89afe862b8992334bbe7953adad56cd1199358cb30566"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.13.0",
  "libc",
- "quick-xml 0.30.0",
+ "quick-xml",
 ]
 
 [[package]]


### PR DESCRIPTION
## TL;DR

- **All open advisories are clear** in both lockfiles (h2, event-listener, quick-xml) via targeted `cargo update -p`, not a blanket update. Diff is 5 crates.
- **New `Advisories` workflow** gates every PR, push to `main`, and a nightly run. It blocks on vulnerabilities and unsoundness. It deliberately does **not** block on `unmaintained`, and carries **one** explicit ignore (`RUSTSEC-2024-0429`, glib, Linux-only). Both are announced in the job summary, never silent.
- **The one soft-fail** is an unreachable advisory database after 3 retries. It cannot mask a finding, because no audit runs in that branch.
- **Found in passing:** the two lockfiles were pinning *different* `rdev` commits. `daemon` was on `23e24dd`, `desktop` on `871bf1c` from five weeks earlier. This is the crate that installs the global keyboard and mouse hooks. Both now build the same reviewed commit, and the manifest pins it so it cannot float again.

`closes #93`

---

## Context

Dependabot was bumping versions weekly, but nothing failed the build on a known-vulnerable lockfile, so CI went green on one. This adds the gate and clears what was already open.

### Correction to the issue's framing

The issue says three advisories "land on crates that build on shipped targets". Checking the dependency graph per target, only two of the three actually do. Everything is fixed regardless — the bumps were cheap — but the risk ranking is worth recording:

| Advisory | Crate | Reached from | On macOS / Windows? |
|---|---|---|---|
| RUSTSEC-2026-0258 (DoS) | `h2 0.4.15` | `axum` / `reqwest` → `hyper` | **Yes** — real exposure |
| RUSTSEC-2026-0194/0195 (DoS) | `quick-xml 0.39.4` | `tauri`/`tauri-codegen` → `plist` | **Yes** — real exposure |
| RUSTSEC-2026-0194/0195 (DoS) | `quick-xml 0.30.0` | `active-win-pos-rs` → `xcb` (build-dep) | No — X11, Linux only |
| RUSTSEC-2026-0221 (unsound) | `event-listener 5.4.1` | `tauri-plugin-opener` → `zbus` | No — D-Bus, Linux only |

Verified with `cargo tree -i <crate> --target aarch64-apple-darwin` and `--target x86_64-pc-windows-msvc`; the two "No" rows print nothing on both.

---

## Changes

### 1. Advisories cleared — both workspaces, targeted updates only

```
daemon:   h2 0.4.15 → 0.4.17, xcb 1.7.0 → 1.7.1 (pulls quick-xml 0.30.0 → 0.41.0)
desktop:  h2 0.4.15 → 0.4.17, event-listener 5.4.1 → 5.4.2,
          plist 1.9.0 → 1.10.0 and xcb 1.7.0 → 1.7.1
          (together collapse quick-xml 0.30.0 + 0.39.4 → a single 0.41.0)
```

`quick-xml` needed `>= 0.41.0`, which is a semver-major move from both 0.30 and 0.39. It did **not** need forcing: `plist 1.10.0` and `xcb 1.7.1` had both already moved to `quick-xml ^0.41`, and both are in-range minor/patch bumps of their parents. No `[patch]` section, no pinned-back versions, no blanket `cargo update`.

`cargo audit` before / after, same command:

```
before:  daemon  → 3 vulnerabilities
         desktop → 5 vulnerabilities + 1 denied warning (event-listener unsound)
after:   daemon  → clean
         desktop → clean (16 unmaintained warnings, allowed — see below)
```

**Lockfile churn to expect in review.** Re-resolving also re-pinned ~10 `windows-sys` dependency edges per lockfile from `0.61.2` back down to each crate's own declared range (`rustix`→0.52.0, `winapi-util`→0.48.0, `socket2`→0.60.2, …). This is not something these bumps chose: `cargo update -p h2` alone reproduces it on `main`, so the next Dependabot PR would have carried it instead. No `windows-sys` package version was added or removed — the set of six is byte-identical before and after — and every new edge sits inside the requirement its own crate declares. The Windows CI jobs build it.

### 2. New `Advisories` workflow (`.github/workflows/audit.yml`)

Runs `cargo audit` over `daemon/Cargo.lock` and `desktop/src-tauri/Cargo.lock` on every PR, every push to `main`, nightly at 06:27 UTC, and on demand. It only reads lockfiles: no toolchain build, no staged icons, no `npm install`, ~1 minute warm.

**Does a brand-new advisory break every unrelated PR? Yes, on purpose.** The fix is nearly always one line, this repo ships a signed agent that installs global input hooks, and the nightly run against `main` normally finds a new advisory before it lands on anyone's branch. A blocked PR is much cheaper than a vulnerable release. The escape hatch is a reviewed diff, not a flag.

Three deliberate carve-outs, each stated in the workflow and echoed into the job summary on every run:

| Carve-out | Why |
|---|---|
| `unmaintained` reported but **not denied** | By definition there is no fixed version to move to, so a blocking gate could only ever be satisfied by ignoring it. Currently 16: the Linux GTK3 stack Tauri pulls in (`gtk`, `gdk`, `atk`, …), plus `proc-macro-error` and the `unic-*` crates. They print in full on every run. |
| **One** explicit ignore: `RUSTSEC-2024-0429` | `glib 0.18.5`, unsound `VariantStrIter`. Reached only via `tauri → tray-icon → libappindicator → gtk`; `cargo tree -i glib` prints nothing for either `aarch64-apple-darwin` or `x86_64-pc-windows-msvc`, so it is not compiled into anything we ship. GTK3 bindings are retired, so there is no fixed release. Without this the gate would be permanently red on a crate we do not build. |
| Yanked-crate detection off in the **blocking** step | It requires a live crates.io index fetch, which is the flakiest thing `cargo audit` does. It still runs in the non-blocking report step below, so yanked crates stay visible. |

**Flakiness.** The advisory DB is cloned in its own step, retried 3× with backoff, and the audit itself runs `--no-fetch --db <clone>` so it is hermetic afterwards. The DB is never cached — a stale advisory DB is a gate that quietly stops catching things.

**The one soft-fail.** If all three clone attempts fail, the job emits a `::warning::` annotation, writes a "**Advisory gate SKIPPED — nothing was audited**" block into the job summary, and passes. This is reachable only when GitHub is unreachable, and it cannot hide a finding because in that branch `cargo audit` never ran at all. Every *found* advisory is a hard failure.

A second, always-`continue-on-error` step dumps the full unfiltered `cargo audit` output for both lockfiles into the job summary, so the things the gate does not block on stay in front of us.

`cargo-audit` is version-pinned (0.22.2) and cached; only `actions/checkout` and `actions/cache` are used.

### 3. `rdev` pinned to an exact commit

`daemon/Cargo.toml` now carries `rev = "23e24dd6b35452a495dae0ae6d99395e9755ab0f"`.

The drift was already real, not hypothetical:

```
daemon/Cargo.lock            git+.../rdev#23e24dd…   (2026-07-24, master HEAD)
desktop/src-tauri/Cargo.lock git+.../rdev#871bf1c…   (2026-06-20)
```

Two workspaces, two different builds of the crate that installs the global keyboard and mouse hooks, from a personal fork off crates.io — and the shipped desktop app was on the older one. Pinning the manifest moves `desktop` onto `23e24dd`, the commit `daemon` has been testing against, and means a lockfile regeneration can no longer follow that fork's default branch. Both lockfiles now read `?rev=23e24dd…#23e24dd…`. Changing this SHA in future should be its own PR.

### 4. Hygiene

**`permissions: contents: read`** added to `ci.yml` and `pr-lint.yml`. Neither writes anything back — `ci.yml` is fmt/clippy/test, `pr-lint.yml` reads the PR title and body off the event payload.

**Fresh-clone trap.** `.githooks/pre-commit` now checks for the six icons the desktop crate needs before running anything, and exits with the exact staging command if they are missing:

```
ERROR: desktop/src-tauri/icons/ is not staged, so the desktop crate cannot build.
Missing:
  - desktop/src-tauri/icons/32x32.png
  ...
Stage the production icons (what CI uses) by running this from the repo root:

  mkdir -p desktop/src-tauri/icons && cp -r desktop/src-tauri/icons_prod/. desktop/src-tauri/icons/
```

**Fail-fast rather than auto-stage, for two reasons.** First, auto-staging would have to pick `icons_dev` or `icons_prod` — silently overwriting a developer's dev-staged `icons/` with prod branding partway through a commit is exactly the kind of surprise that costs an hour to spot, and a commit hook should not mutate the working tree behind the author's back. Second, and this is probably why three people got stuck: the advice "run `scripts/dev.sh`" *doesn't work as an instruction*, because that script stages the icons and then launches the app and blocks. There was no staging-only command to point anyone at, so the hook prints it. `CONTRIBUTING.md` now documents it as a once-per-clone step, alongside how to reproduce the advisory gate locally.

The hook also `cd`s to the repo root first, matching `scripts/dev.sh`.

---

## Verification

Run in `daemon/` then `desktop/src-tauri/`, plus a full clean run of the modified pre-commit hook on commit:

| Command | daemon | desktop/src-tauri |
|---|---|---|
| `cargo fmt -- --check` | pass | pass |
| `cargo clippy -- -D warnings` | pass | pass |
| `cargo test` | **122 passed, 0 failed** (122 before) | **8 passed, 0 failed** (8 before) |

No test count changed across the bumps.

Gate tested both directions against a real `RustSec/advisory-db` clone:

```
this branch → daemon exit 0, desktop exit 0                    (gate passes)
HEAD locks  → daemon "3 vulnerabilities", desktop "5 vulnerabilities
              + 1 denied warning"                              (gate fails, as intended)
```

The pre-commit icon guard was exercised in a simulated fresh clone under `/bin/bash` 3.2: fails with the message above when `icons/` is absent, passes after running the printed command. All five workflow files parse as YAML and every `run:` script passes `bash -n`.

Not merged and auto-merge not enabled.
