### PR TITLE
fix(desktop): set a CSP and keep the signing key out of the webview

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -40,7 +40,7 @@ auditable; the cloud portal is not part of this repository.
 | 7 | Focus-scoring rules are deterministic and inspectable | ✅ Verified | [evaluator.rs](daemon/src/evaluator.rs), [entropy.rs](daemon/src/entropy.rs) |
 | 8 | Local logs are tamper-evident (full-payload hash chain) + self-signed when enrolled | ✅ Verified | [db.rs `insert_slot_summary`/`verify_ledger_integrity`](daemon/src/db.rs) — work notes have their own chain, same construction (§5) |
 | 9 | Your daily work note describes the task, not the window title | ⚠️ Prompt-enforced, not mechanism-enforced | The default prompt ([config.rs:51](daemon/src/config.rs#L51)) tells the model never to quote a window title, file path, URL, or third-party name. Nothing inspects the sentence afterwards: `sanitize_note` ([llm.rs:108](daemon/src/llm.rs#L108)) rejects empty or essay-length replies, not leaked content. The prompt's SHA-256 is bound into the signed record so a reader can check which rules applied — that is evidence of the rule, not proof the model obeyed it |
-| — | Secrets stored in OS keychain | ✅ Verified | [config.rs `save_config`/`load_config`](daemon/src/config.rs) — `private_key` & `llm_api_key` kept in the OS keychain via the `keyring` crate |
+| — | Secrets stored in OS keychain, and the signing key never reaches the app window | ✅ Verified | [config.rs `save_config`/`load_config`](daemon/src/config.rs) — `private_key` & `llm_api_key` kept in the OS keychain via the `keyring` crate. Since #94 the settings UI is sent a redacted config with no `private_key` and no API key value ([lib.rs](desktop/src-tauri/src/lib.rs)); the API key is write-only and the app runs under a `default-src 'self'` CSP — see G2 |
 | — | Local dashboard makes no third-party calls | ✅ Verified | [dashboard.rs](daemon/src/dashboard.rs) — Outfit font embedded as a data URI; no CDN `<link>` |
 | — | The installed app opens **no listening port** | ✅ Verified | The dashboard renders in-app over Tauri IPC. The loopback HTTP server is a debug-only escape hatch for the standalone `daemon` binary, off unless `TENBY10_DEBUG_HTTP` is set — [env.rs `debug_http_enabled`](daemon/src/env.rs) |
 
@@ -366,12 +366,34 @@ real mismatches to close:
   deleted ([ADR 0018](../decisions/0018-remove-screenshot-subsystem.md)): no toggle, no capture code,
   no image path to any provider. See §3.
 
-- **G2 — Secrets are handed to the settings UI over local IPC.** `private_key` and `llm_api_key`
-  live in the OS keychain and `config.json` is written sanitized with those fields blanked
-  ([config.rs](daemon/src/config.rs)), so nothing sensitive is at rest in plaintext. The one caveat
-  an auditor should note: over the local Tauri IPC channel, `get_agent_config` still returns the
-  in-memory config *including* those secrets so the settings form can render them — an in-process
-  transfer to the app you launched, not at-rest plaintext on disk.
+- **G2 — CLOSED for the signing key; narrowed for the API key (#94).** `private_key` and
+  `llm_api_key` live in the OS keychain and `config.json` is written sanitized with those fields
+  blanked ([config.rs](daemon/src/config.rs)), so nothing sensitive is at rest in plaintext. What
+  used to be the caveat here — `get_agent_config` returning the in-memory config *including* both
+  secrets so the settings form could render them — is gone. `get_agent_config` now returns a
+  redacted view ([lib.rs](desktop/src-tauri/src/lib.rs)) with no `private_key` field at all and no
+  API key value, only a boolean `llm_api_key_set`. The Ed25519 signing key never crosses the IPC
+  boundary into the webview in either direction, so no markup-injection bug in that window could
+  reach it. The BYOK API key is write-only: it travels app → backend when you type one and is
+  never handed back.
+
+  Two things an auditor should still weigh. First, the API key does cross that boundary on the way
+  in, which is unavoidable — you have to type it somewhere. Second, `withGlobalTauri` is still on,
+  so `window.__TAURI__` is present; note that turning it off would not remove the IPC surface,
+  because `window.__TAURI_INTERNALS__.invoke` is injected by Tauri regardless and can call any
+  registered command. What actually bounds that surface now is the Content-Security-Policy the app
+  ships with (`default-src 'self'`, `script-src 'self'` with no `unsafe-inline`, `connect-src`
+  limited to Tauri's own IPC scheme) — injected script cannot load, and cannot reach any remote
+  host to send anything to.
+
+  One related failure was closed with it. `save_config` treats an empty secret as a keychain
+  *delete*, and the settings form used to avoid wiping the signing key only by re-fetching the
+  whole config and posting it back. Now that the form never receives it, `save_agent_config` takes
+  a payload that structurally cannot express a secret and merges it into the stored configuration,
+  so anything the form does not own is preserved by never leaving the backend. Locked by
+  `a_save_without_secrets_leaves_the_keychain_intact` and
+  `a_save_with_no_config_file_still_keeps_a_stored_signing_key`
+  ([lib.rs](desktop/src-tauri/src/lib.rs)).
 
 - **G3 — NARROWED (#83).** A work note (§2) is written from window titles by your own AI, and this
   used to rest entirely on `default_summary_prompt` asking the model not to quote one

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -5098,6 +5098,7 @@ version = "0.1.0"
 dependencies = [
  "daemon",
  "fs2",
+ "keyring",
  "reqwest",
  "serde",
  "serde_json",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -28,3 +28,9 @@ tokio = { version = "1.37", features = ["full"] }
 reqwest = { version = "0.13", features = ["json"] }
 fs2 = "0.4.3"
 
+[dev-dependencies]
+# Only so the settings-save tests can swap in the in-memory mock credential store.
+# Must track the version `daemon` uses, or `set_default_credential_builder` would be
+# configuring a different keyring than the one `daemon::config` reads and writes.
+keyring = { version = "3", features = ["apple-native", "windows-native"] }
+

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -548,12 +548,167 @@ async fn export_dashboard_csv(
     Ok(Some(path.to_string_lossy().to_string()))
 }
 
-#[tauri::command]
-async fn get_agent_config() -> Result<daemon::config::AgentConfig, String> {
-    let app_home = daemon::env::get_app_home();
-    let mut config_path = app_home.clone();
+/// Everything the settings form needs to render itself — and nothing else.
+///
+/// The Ed25519 signing key is deliberately absent: it never crosses the IPC
+/// boundary into the webview at all, so no amount of markup injection in that
+/// window can read it. Stealing it would mean forging the ledger this product
+/// exists to sell. The BYOK API key is absent for the same reason, replaced by
+/// [`Self::llm_api_key_set`] so the form can say "a key is saved" without
+/// holding one. `enrollment_token` is left out too: the form never shows it, and
+/// what is not sent cannot leak.
+///
+/// See AUDIT.md gap G2.
+#[derive(serde::Serialize)]
+struct RedactedAgentConfig {
+    agent_id: String,
+    public_key: String,
+    distracting_apps: String,
+    productive_apps: String,
+    meeting_apps: String,
+    engine_mode: String,
+    llm_provider: String,
+    /// Whether a BYOK API key is stored in the OS keychain. The value itself is
+    /// write-only (see [`AgentConfigUpdate::llm_api_key`]) and is never returned.
+    llm_api_key_set: bool,
+    llm_base_url: String,
+    llm_model: String,
+    llm_prompt: String,
+    summary_prompt: String,
+    disable_work_summaries: bool,
+    enforce_synthetic_detection: bool,
+}
+
+impl From<&daemon::config::AgentConfig> for RedactedAgentConfig {
+    fn from(config: &daemon::config::AgentConfig) -> Self {
+        Self {
+            agent_id: config.agent_id.clone(),
+            public_key: config.public_key.clone(),
+            distracting_apps: config.distracting_apps.clone(),
+            productive_apps: config.productive_apps.clone(),
+            meeting_apps: config.meeting_apps.clone(),
+            engine_mode: config.engine_mode.clone(),
+            llm_provider: config.llm_provider.clone(),
+            llm_api_key_set: !config.llm_api_key.is_empty(),
+            llm_base_url: config.llm_base_url.clone(),
+            llm_model: config.llm_model.clone(),
+            llm_prompt: config.llm_prompt.clone(),
+            summary_prompt: config.summary_prompt.clone(),
+            disable_work_summaries: config.disable_work_summaries,
+            enforce_synthetic_detection: config.enforce_synthetic_detection,
+        }
+    }
+}
+
+/// The fields the settings form owns, as the form sends them.
+///
+/// This payload structurally cannot carry the signing key — that is the point.
+/// [`save_agent_config`] merges it into the stored configuration, so identity and
+/// secrets survive a save because nothing in the message could have expressed
+/// them in the first place.
+#[derive(serde::Deserialize)]
+struct AgentConfigUpdate {
+    distracting_apps: String,
+    productive_apps: String,
+    meeting_apps: String,
+    engine_mode: String,
+    llm_provider: String,
+    /// Write-only: the BYOK API key only ever travels app → backend, never back.
+    /// `None` (omitted, or JSON `null`) keeps whatever is in the keychain, which
+    /// is what an untouched field means now that the form never receives the
+    /// stored value. `Some("")` deletes it. `Some(key)` replaces it.
+    #[serde(default)]
+    llm_api_key: Option<String>,
+    llm_base_url: String,
+    llm_model: String,
+    llm_prompt: String,
+    summary_prompt: String,
+    disable_work_summaries: bool,
+}
+
+fn agent_config_path() -> std::path::PathBuf {
+    let mut config_path = daemon::env::get_app_home();
     config_path.push("config.json");
-    daemon::config::load_config(config_path)
+    config_path
+}
+
+#[tauri::command]
+async fn get_agent_config() -> Result<RedactedAgentConfig, String> {
+    daemon::config::load_config(agent_config_path())
+        .map(|config| RedactedAgentConfig::from(&config))
+}
+
+/// Fold a settings update into an already-loaded configuration.
+///
+/// Everything absent from `update` is left exactly as it was, which is what keeps
+/// `private_key`, `agent_id`, `public_key` and `enrollment_token` intact across a
+/// save. `llm_api_key` is the one secret the form can write, and only when it
+/// actually says so.
+fn apply_settings_update(config: &mut daemon::config::AgentConfig, update: AgentConfigUpdate) {
+    config.distracting_apps = update.distracting_apps;
+    config.productive_apps = update.productive_apps;
+    config.meeting_apps = update.meeting_apps;
+    config.engine_mode = update.engine_mode;
+    config.llm_provider = update.llm_provider;
+    config.llm_base_url = update.llm_base_url;
+    config.llm_model = update.llm_model;
+    config.llm_prompt = update.llm_prompt;
+    config.summary_prompt = update.summary_prompt;
+    config.disable_work_summaries = update.disable_work_summaries;
+    if let Some(api_key) = update.llm_api_key {
+        // An empty string here is a deliberate delete — `save_config` clears the
+        // keychain entry for an empty secret. That is only ever reached when the
+        // user emptied the field on purpose; an untouched field sends `None`.
+        config.llm_api_key = api_key;
+    }
+}
+
+/// Make sure `config.json` exists before a settings save reads it.
+///
+/// `load_config` short-circuits to `AgentConfig::default()` when the file is
+/// missing and — on that path only — never consults the OS keychain. Handing that
+/// default to `save_config` would pass an empty `private_key`, which `save_config`
+/// reads as "delete the keychain entry": a settings save made while the file
+/// happened to be absent would destroy a signing identity that was still sitting
+/// in the keychain, orphaning every slot already signed under it.
+///
+/// Seeding an empty skeleton first sends the load down its normal overlay path, so
+/// any stored secret comes back with it and is written straight back out. The
+/// skeleton carries no secrets and is exactly what `save_config` writes for a
+/// brand-new install, so this is a no-op on first run.
+///
+/// This guard belongs in `daemon::config::load_config`; it lives here because that
+/// file is owned by another change in flight (see the PR for #94).
+fn ensure_agent_config_file(config_path: &std::path::Path) -> Result<(), String> {
+    if config_path.exists() {
+        return Ok(());
+    }
+    if let Some(parent) = config_path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|err| format!("Failed to create config directory: {}", err))?;
+    }
+    // The four fields `AgentConfig` has no serde default for. Everything else fills
+    // in from the struct's own defaults.
+    let skeleton = serde_json::json!({
+        "agent_id": "",
+        "enrollment_token": "",
+        "public_key": "",
+        "private_key": "",
+    });
+    std::fs::write(config_path, skeleton.to_string())
+        .map_err(|err| format!("Failed to create config file: {}", err))
+}
+
+/// Path-parameterised form of [`save_agent_config`], so the merge can be tested
+/// without pointing the whole app at a temp directory.
+fn save_agent_config_at(
+    config_path: std::path::PathBuf,
+    update: AgentConfigUpdate,
+) -> Result<(), String> {
+    ensure_agent_config_file(&config_path)?;
+    let mut config = daemon::config::load_config(config_path.clone())?;
+    apply_settings_update(&mut config, update);
+    daemon::config::save_config(config_path, &config)
 }
 
 /// The endpoint and model each provider actually calls when the user leaves
@@ -589,11 +744,8 @@ async fn get_max_prompt_bytes() -> Result<usize, String> {
 }
 
 #[tauri::command]
-async fn save_agent_config(new_config: daemon::config::AgentConfig) -> Result<(), String> {
-    let app_home = daemon::env::get_app_home();
-    let mut config_path = app_home.clone();
-    config_path.push("config.json");
-    daemon::config::save_config(config_path, &new_config)
+async fn save_agent_config(new_config: AgentConfigUpdate) -> Result<(), String> {
+    save_agent_config_at(agent_config_path(), new_config)
 }
 
 #[tauri::command]
@@ -838,6 +990,305 @@ pub fn run() {
         })
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
+}
+
+/// The settings form no longer sees the signing key, so nothing on the round trip
+/// can put it back. That makes these tests the only thing standing between a
+/// settings save and a destroyed signing identity: `save_config` treats an empty
+/// secret as a keychain *delete*, and a deleted signing key orphans every slot the
+/// ledger already carries. Read them as a safety interlock, not as coverage.
+#[cfg(test)]
+mod settings_save_tests {
+    use super::{save_agent_config_at, AgentConfigUpdate, RedactedAgentConfig};
+    use daemon::config::{load_config, save_config, AgentConfig};
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::{Mutex, MutexGuard, Once};
+
+    static INIT_KEYCHAIN: Once = Once::new();
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+    /// One process-wide store keyed by service + account, exactly like the real
+    /// thing — so every test in here writes to the same two slots. Serialise them
+    /// rather than let cargo's thread pool interleave a save with another test's
+    /// assertion.
+    static KEYCHAIN: Mutex<()> = Mutex::new(());
+    static STORE: Mutex<Option<HashMap<String, Vec<u8>>>> = Mutex::new(None);
+
+    /// A stand-in keychain that actually remembers what was written to it.
+    ///
+    /// `keyring::mock` cannot be used here: it hands out a fresh, empty credential
+    /// per `Entry::new`, so a value written through one entry is invisible to the
+    /// next one — which would make "the stored key survived" pass whether or not it
+    /// did. These tests exist to catch a *deleted* signing key, so the store has to
+    /// distinguish "still there" from "gone", and that needs real persistence keyed
+    /// by service and account.
+    #[derive(Debug)]
+    struct StoreCredential(String);
+
+    impl keyring::credential::CredentialApi for StoreCredential {
+        fn set_secret(&self, secret: &[u8]) -> keyring::Result<()> {
+            let mut store = STORE.lock().unwrap_or_else(|e| e.into_inner());
+            store
+                .get_or_insert_with(HashMap::new)
+                .insert(self.0.clone(), secret.to_vec());
+            Ok(())
+        }
+
+        fn get_secret(&self) -> keyring::Result<Vec<u8>> {
+            let store = STORE.lock().unwrap_or_else(|e| e.into_inner());
+            match store.as_ref().and_then(|s| s.get(&self.0)) {
+                Some(secret) => Ok(secret.clone()),
+                None => Err(keyring::Error::NoEntry),
+            }
+        }
+
+        fn delete_credential(&self) -> keyring::Result<()> {
+            let mut store = STORE.lock().unwrap_or_else(|e| e.into_inner());
+            match store.as_mut().and_then(|s| s.remove(&self.0)) {
+                Some(_) => Ok(()),
+                None => Err(keyring::Error::NoEntry),
+            }
+        }
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+
+    #[derive(Debug)]
+    struct StoreBuilder;
+
+    impl keyring::credential::CredentialBuilderApi for StoreBuilder {
+        fn build(
+            &self,
+            _target: Option<&str>,
+            service: &str,
+            user: &str,
+        ) -> keyring::Result<Box<keyring::Credential>> {
+            Ok(Box::new(StoreCredential(format!("{service}\u{0}{user}"))))
+        }
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+
+        fn persistence(&self) -> keyring::credential::CredentialPersistence {
+            keyring::credential::CredentialPersistence::ProcessOnly
+        }
+    }
+
+    /// Route keychain access to the in-process store so tests never touch — or
+    /// prompt for — the real OS keychain.
+    fn keychain() -> MutexGuard<'static, ()> {
+        INIT_KEYCHAIN.call_once(|| {
+            keyring::set_default_credential_builder(Box::new(StoreBuilder));
+        });
+        KEYCHAIN
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn temp_config_path() -> PathBuf {
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let mut path = std::env::temp_dir();
+        path.push(format!(
+            "tenby10_desktop_cfg_test_{}_{}.json",
+            std::process::id(),
+            n
+        ));
+        path
+    }
+
+    /// An enrolled device: identity and both secrets stored the way the app stores
+    /// them (keychain for the secrets, sanitized JSON on disk).
+    fn enrolled(path: &PathBuf) -> AgentConfig {
+        let mut config = daemon::config::generate_enrollment_keys("tok");
+        config.agent_id = "agent_under_test".to_string();
+        config.llm_provider = "openai".to_string();
+        config.llm_api_key = "sk-the-users-own-key".to_string();
+        save_config(path.clone(), &config).expect("the baseline save should succeed");
+        config
+    }
+
+    /// What the settings form sends: rules and prompts, no secrets, `llm_api_key`
+    /// left as `None` because the user did not touch the field.
+    fn settings_only_update() -> AgentConfigUpdate {
+        AgentConfigUpdate {
+            distracting_apps: "youtube".to_string(),
+            productive_apps: "vscode".to_string(),
+            meeting_apps: "zoom".to_string(),
+            engine_mode: "llm".to_string(),
+            llm_provider: "anthropic".to_string(),
+            llm_api_key: None,
+            llm_base_url: String::new(),
+            llm_model: String::new(),
+            llm_prompt: daemon::config::default_llm_prompt(),
+            summary_prompt: daemon::config::default_summary_prompt(),
+            disable_work_summaries: false,
+        }
+    }
+
+    /// The one that matters. A save carrying no secrets must leave the keychain
+    /// entries exactly as they were — the signing key above all, since losing it
+    /// orphans the ledger it signed.
+    #[test]
+    fn a_save_without_secrets_leaves_the_keychain_intact() {
+        let _guard = keychain();
+        let path = temp_config_path();
+        let before = enrolled(&path);
+
+        save_agent_config_at(path.clone(), settings_only_update())
+            .expect("the save should succeed");
+
+        let after = load_config(path.clone()).expect("the config should still load");
+        assert_eq!(
+            after.private_key, before.private_key,
+            "the signing key must survive a settings save"
+        );
+        assert_eq!(
+            after.llm_api_key, before.llm_api_key,
+            "an untouched API key field must keep the stored key"
+        );
+        // Identity the form never sees is preserved for the same reason.
+        assert_eq!(after.public_key, before.public_key);
+        assert_eq!(after.agent_id, "agent_under_test");
+        assert_eq!(after.enrollment_token, before.enrollment_token);
+        // And the settings the form *did* send actually landed.
+        assert_eq!(after.productive_apps, "vscode");
+        assert_eq!(after.engine_mode, "llm");
+        assert_eq!(after.llm_provider, "anthropic");
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// `load_config` skips the keychain overlay entirely when `config.json` is
+    /// missing, so without the skeleton guard this exact sequence would hand
+    /// `save_config` an empty `private_key` and delete a live signing key.
+    #[test]
+    fn a_save_with_no_config_file_still_keeps_a_stored_signing_key() {
+        let _guard = keychain();
+        let path = temp_config_path();
+        let before = enrolled(&path);
+        std::fs::remove_file(&path).expect("the config file should exist to be removed");
+
+        save_agent_config_at(path.clone(), settings_only_update())
+            .expect("the save should succeed");
+
+        let after = load_config(path.clone()).expect("the config should load");
+        assert_eq!(
+            after.private_key, before.private_key,
+            "a missing config.json must not cost the user their signing key"
+        );
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// Clearing the field is the one way the form deletes a stored API key — and it
+    /// must still be the only secret that moves.
+    #[test]
+    fn clearing_the_api_key_deletes_only_the_api_key() {
+        let _guard = keychain();
+        let path = temp_config_path();
+        let before = enrolled(&path);
+
+        let update = AgentConfigUpdate {
+            llm_api_key: Some(String::new()),
+            ..settings_only_update()
+        };
+        save_agent_config_at(path.clone(), update).expect("the save should succeed");
+
+        let after = load_config(path.clone()).expect("the config should load");
+        assert!(
+            after.llm_api_key.is_empty(),
+            "an emptied field must remove the stored key"
+        );
+        assert_eq!(
+            after.private_key, before.private_key,
+            "clearing the API key must not touch the signing key"
+        );
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn a_typed_api_key_replaces_the_stored_one() {
+        let _guard = keychain();
+        let path = temp_config_path();
+        let before = enrolled(&path);
+
+        let update = AgentConfigUpdate {
+            llm_api_key: Some("sk-a-brand-new-key".to_string()),
+            ..settings_only_update()
+        };
+        save_agent_config_at(path.clone(), update).expect("the save should succeed");
+
+        let after = load_config(path.clone()).expect("the config should load");
+        assert_eq!(after.llm_api_key, "sk-a-brand-new-key");
+        assert_eq!(after.private_key, before.private_key);
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// A rejected save must not half-apply: the API key is written by the same
+    /// `save_config` call that validates the prompts, so a refusal leaves both alone.
+    #[test]
+    fn a_rejected_save_changes_no_secret() {
+        let _guard = keychain();
+        let path = temp_config_path();
+        let before = enrolled(&path);
+
+        let update = AgentConfigUpdate {
+            llm_prompt: "x".repeat(daemon::config::MAX_PROMPT_BYTES + 1),
+            llm_api_key: Some("sk-should-never-land".to_string()),
+            ..settings_only_update()
+        };
+        save_agent_config_at(path.clone(), update)
+            .expect_err("an over-long prompt must be refused");
+
+        let after = load_config(path.clone()).expect("the config should load");
+        assert_eq!(after.llm_api_key, before.llm_api_key);
+        assert_eq!(after.private_key, before.private_key);
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// The reason all of the above is safe to rely on: the webview is never sent a
+    /// secret it could hand back. Asserted on the serialized JSON, since that is
+    /// what actually crosses the IPC boundary.
+    #[test]
+    fn the_redacted_config_carries_no_secret_over_ipc() {
+        let mut config = daemon::config::generate_enrollment_keys("tok_secret");
+        config.llm_api_key = "sk-super-secret-key".to_string();
+        let private_key = config.private_key.clone();
+        assert!(!private_key.is_empty());
+
+        let json = serde_json::to_string(&RedactedAgentConfig::from(&config))
+            .expect("the redacted config should serialize");
+
+        assert!(
+            !json.contains(&private_key),
+            "the signing key must never cross into the webview: {json}"
+        );
+        assert!(
+            !json.contains("private_key"),
+            "not even the field should exist: {json}"
+        );
+        assert!(
+            !json.contains("sk-super-secret-key"),
+            "the API key value must never cross into the webview: {json}"
+        );
+        assert!(
+            !json.contains("tok_secret"),
+            "the enrollment token is not the form's business either: {json}"
+        );
+        // What the form does get: enough to say "a key is saved".
+        assert!(json.contains("\"llm_api_key_set\":true"), "was: {json}");
+
+        config.llm_api_key = String::new();
+        let json = serde_json::to_string(&RedactedAgentConfig::from(&config)).expect("serializes");
+        assert!(json.contains("\"llm_api_key_set\":false"), "was: {json}");
+    }
 }
 
 #[cfg(test)]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -20,7 +20,7 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src ipc: http://ipc.localhost; frame-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'"
     }
   },
   "bundle": {

--- a/desktop/src/dashboard.html
+++ b/desktop/src/dashboard.html
@@ -6,8 +6,11 @@
     <title>tenby10 Dashboard</title>
     <link rel="icon" type="image/png" href="favicon.png">
     <link rel="stylesheet" href="dashboard.css">
-    <!-- Classic (non-module) script so inline on* handlers resolve to globals,
-         and window.__TAURI__ (withGlobalTauri) is available. -->
+    <!-- Classic (non-module) script: this document is loaded in an iframe, where
+         Tauri injects nothing (its init scripts are main-frame only), so dashboard.js
+         reaches the bridge through window.parent. Every control below is wired up
+         there with addEventListener — the app sets script-src 'self', which blocks
+         inline on* handlers and javascript: URLs outright. -->
     <script src="dashboard.js" defer></script>
 </head>
 <body>
@@ -22,7 +25,7 @@
             </div>
         </div>
         <div style="display: flex; gap: 1rem; align-items: center;">
-            <button class="nav-btn" onclick="openExportModal()">📥 Export Data</button>
+            <button type="button" class="nav-btn" id="export-open-btn">📥 Export Data</button>
             <div class="status-badge">Active Local Agent</div>
         </div>
     </header>
@@ -54,28 +57,28 @@
             <div class="day-navigation" style="display: flex; justify-content: space-between; align-items: center; background: var(--bg-card); border: 1px solid var(--border-card); border-radius: 16px; padding: 1rem 1.5rem; backdrop-filter: blur(20px); flex-wrap: wrap; gap: 1rem;">
                 <div style="display: flex; gap: 1rem; align-items: center;">
                     <div style="display: flex; background: rgba(0,0,0,0.2); border-radius: 8px; padding: 2px;">
-                        <button class="nav-btn view-tab" id="tab-monthly" onclick="switchView('monthly')" style="padding: 0.4rem 1rem; border: none; background: transparent;">Monthly</button>
-                        <button class="nav-btn view-tab" id="tab-weekly" onclick="switchView('weekly')" style="padding: 0.4rem 1rem; border: none; background: transparent;">Weekly</button>
-                        <button class="nav-btn view-tab active" id="tab-daily" onclick="switchView('daily')" style="padding: 0.4rem 1rem; border: none; background: transparent;">Daily</button>
+                        <button type="button" class="nav-btn view-tab" id="tab-monthly" data-view="monthly" style="padding: 0.4rem 1rem; border: none; background: transparent;">Monthly</button>
+                        <button type="button" class="nav-btn view-tab" id="tab-weekly" data-view="weekly" style="padding: 0.4rem 1rem; border: none; background: transparent;">Weekly</button>
+                        <button type="button" class="nav-btn view-tab active" id="tab-daily" data-view="daily" style="padding: 0.4rem 1rem; border: none; background: transparent;">Daily</button>
                     </div>
                     <div style="display: flex; gap: 0.8rem;">
-                        <button class="nav-btn" id="prev-day-btn" onclick="prevDay()">◀ Prev</button>
-                        <button class="nav-btn" id="next-day-btn" onclick="nextDay()">Next ▶</button>
+                        <button type="button" class="nav-btn" id="prev-day-btn">◀ Prev</button>
+                        <button type="button" class="nav-btn" id="next-day-btn">Next ▶</button>
                     </div>
                 </div>
                 
                 <div style="display: flex; align-items: center; gap: 1.5rem;">
                     <div id="week-start-container" style="display: flex; align-items: center; gap: 0.5rem; display: none;">
                         <span style="font-size: 0.75rem; color: var(--text-muted); font-weight: 600;">Week Start:</span>
-                        <select id="week-start-select" onchange="updateWeekStart(this.value)" class="custom-date-picker" style="padding: 0.3rem 0.5rem; font-size: 0.75rem;">
+                        <select id="week-start-select" class="custom-date-picker" style="padding: 0.3rem 0.5rem; font-size: 0.75rem;">
                             <option value="1">Monday</option>
                             <option value="0">Sunday</option>
                         </select>
                     </div>
                     <div style="display: flex; align-items: center; gap: 0.8rem;">
-                        <a href="javascript:void(0)" id="today-btn" onclick="navigateToToday()" style="font-size: 0.8rem; color: var(--accent-green); text-decoration: none; font-weight: 600; padding: 0.3rem 0.5rem; border-radius: 4px; background: rgba(16, 185, 129, 0.1);">Today</a>
+                        <a href="#" id="today-btn" style="font-size: 0.8rem; color: var(--accent-green); text-decoration: none; font-weight: 600; padding: 0.3rem 0.5rem; border-radius: 4px; background: rgba(16, 185, 129, 0.1);">Today</a>
                         <span id="date-picker-label" style="font-size: 0.8rem; color: var(--text-muted); font-weight: 600;">Select Date:</span>
-                        <input type="date" id="date-picker" onchange="datePickerChanged(this)" class="custom-date-picker" />
+                        <input type="date" id="date-picker" class="custom-date-picker" />
                     </div>
                 </div>
             </div>
@@ -121,7 +124,7 @@
         <div class="dialog-content">
             <div class="dialog-header">
                 <h3 id="dialog-slot-title">Slot Details</h3>
-                <button class="close-btn" onclick="closeSlotDialog()">✕</button>
+                <button type="button" class="close-btn" id="slot-dialog-close">✕</button>
             </div>
             <div class="dialog-body-grid">
                 <div style="display: flex; flex-direction: column; gap: 0.5rem; flex: 1;">
@@ -142,14 +145,14 @@
         <div class="dialog-content">
             <div class="dialog-header">
                 <h3>Export Telemetry Data</h3>
-                <button class="close-btn" onclick="closeExportModal()">✕</button>
+                <button type="button" class="close-btn" id="export-dialog-close">✕</button>
             </div>
             <div style="display: flex; flex-direction: column; gap: 1rem; margin-top: 1rem;">
                 <p style="font-size: 0.85rem; color: var(--text-muted);">Export a CSV containing your unaggregated, minute-by-minute telemetry logs.</p>
                 
                 <div style="display: flex; flex-direction: column; gap: 0.8rem; margin-top: 0.5rem;">
                     <label style="font-size: 0.8rem; color: var(--text-muted); font-weight: 600;">Time Range</label>
-                    <select id="export-range" onchange="document.getElementById('custom-range-inputs').style.display = this.value === 'custom' ? 'flex' : 'none'" class="custom-date-picker" style="width: 100%; padding: 0.5rem; background: rgba(0,0,0,0.2); border: 1px solid rgba(255,255,255,0.1); color: var(--text-primary); border-radius: 4px;">
+                    <select id="export-range" class="custom-date-picker" style="width: 100%; padding: 0.5rem; background: rgba(0,0,0,0.2); border: 1px solid rgba(255,255,255,0.1); color: var(--text-primary); border-radius: 4px;">
                         <option value="24h">Last 24 Hours</option>
                         <option value="7d">Last 7 Days</option>
                         <option value="30d">Last 30 Days (1 Month)</option>
@@ -171,7 +174,7 @@
                     </div>
                 </div>
                 
-                <button class="scribe-btn" id="export-btn" onclick="exportCsv()" style="margin-top: 0.5rem;">
+                <button type="button" class="scribe-btn" id="export-btn" style="margin-top: 0.5rem;">
                     <span>Download CSV</span>
                 </button>
             </div>

--- a/desktop/src/dashboard.js
+++ b/desktop/src/dashboard.js
@@ -602,7 +602,7 @@ function goHome() {
                     tooltipStr = `${hourStr} - Idle`;
                 }
                 
-                return `<div class="heatmap-cell" onclick="document.getElementById('hour-row-${currentDateKey}-${hour}').scrollIntoView({behavior: 'smooth'})" style="cursor:pointer; display:flex; gap:2px; padding:3px;" data-tooltip="${tooltipStr}">
+                return `<div class="heatmap-cell" data-scroll-to="hour-row-${currentDateKey}-${hour}" style="cursor:pointer; display:flex; gap:2px; padding:3px;" data-tooltip="${tooltipStr}">
                     ${sliversHtml}
                 </div>`;
             }).join('');
@@ -668,7 +668,7 @@ function goHome() {
                                     <div class="slot-compact-stats">
                                         ${statsHtml}
                                     </div>
-                                    <button class="view-slot-compact-btn" onclick="showSlotDetails(${slot.slot_start}, event)">
+                                    <button type="button" class="view-slot-compact-btn" data-slot-start="${slot.slot_start}">
                                         📋 Details
                                     </button>
                                 </div>
@@ -931,7 +931,7 @@ function goHome() {
             }
             
             return `
-                <div class="month-day-cell ${colorClass}" onclick="switchView('daily'); navigateToDate('${dateKey}');">
+                <div class="month-day-cell ${colorClass}" data-goto-date="${dateKey}">
                     <div class="month-day-header">
                         <span>${headerText}</span>
                         <span style="color: var(--text-main);">${dayNum}</span>
@@ -1074,6 +1074,69 @@ function goHome() {
         }
 
 
+
+        // --- Control wiring ---
+        //
+        // The app runs under script-src 'self' (see tauri.conf.json), which blocks
+        // inline on* handlers and javascript: URLs. Everything this document reacts
+        // to is therefore bound here instead. Nothing about the behaviour changed —
+        // the same functions run on the same events.
+
+        function on(id, event, handler) {
+            const el = document.getElementById(id);
+            if (el) el.addEventListener(event, handler);
+        }
+
+        document.querySelectorAll('.view-tab[data-view]').forEach(tab => {
+            tab.addEventListener('click', () => switchView(tab.getAttribute('data-view')));
+        });
+
+        on('prev-day-btn', 'click', prevDay);
+        on('next-day-btn', 'click', nextDay);
+        on('week-start-select', 'change', (e) => updateWeekStart(e.target.value));
+        on('date-picker', 'change', (e) => datePickerChanged(e.target));
+        on('today-btn', 'click', (e) => {
+            // An <a> rather than a button, so keep it from adding a #fragment.
+            e.preventDefault();
+            navigateToToday();
+        });
+
+        on('export-open-btn', 'click', openExportModal);
+        on('export-dialog-close', 'click', closeExportModal);
+        on('export-btn', 'click', exportCsv);
+        on('export-range', 'change', (e) => {
+            const custom = document.getElementById('custom-range-inputs');
+            if (custom) custom.style.display = e.target.value === 'custom' ? 'flex' : 'none';
+        });
+
+        on('slot-dialog-close', 'click', closeSlotDialog);
+
+        // The day/week/month grids are re-rendered from scratch on every poll, so the
+        // cells they contain declare what they do in data-* attributes and one
+        // delegated listener carries it out. Nothing to rebind after a re-render.
+        document.addEventListener('click', (event) => {
+            const target = event.target;
+            if (!(target instanceof Element)) return;
+
+            const scroller = target.closest('[data-scroll-to]');
+            if (scroller) {
+                const row = document.getElementById(scroller.getAttribute('data-scroll-to'));
+                if (row) row.scrollIntoView({ behavior: 'smooth' });
+                return;
+            }
+
+            const slotButton = target.closest('[data-slot-start]');
+            if (slotButton) {
+                showSlotDetails(Number(slotButton.getAttribute('data-slot-start')), event);
+                return;
+            }
+
+            const dayCell = target.closest('[data-goto-date]');
+            if (dayCell) {
+                switchView('daily');
+                navigateToDate(dayCell.getAttribute('data-goto-date'));
+            }
+        });
 
         // When embedded in the app window (iframe), add a Back control to the
         // header that returns to the metrics home. Standalone, this is skipped.

--- a/desktop/src/main.js
+++ b/desktop/src/main.js
@@ -23,7 +23,18 @@ const tabContents = document.querySelectorAll(".tab-content");
 const saveSettingsBtn = document.getElementById("save-settings-btn");
 const aiEngineToggle = document.getElementById("ai-engine-toggle");
 
+// The redacted configuration this window is allowed to see. It carries no signing
+// key and no API key value — see get_agent_config in src-tauri/src/lib.rs.
 let currentConfig = null;
+
+// A saved API key never comes back to this window; it stays in the OS keychain and
+// `get_agent_config` reports only whether one exists. So the field shows a fixed
+// stand-in instead, and the save path reads it as three different intentions:
+//   the stand-in, untouched -> keep the stored key (nothing is sent)
+//   anything else typed in  -> replace it with what was typed
+//   an empty field          -> delete the stored key
+const SAVED_API_KEY_STANDIN = "••••••••••••••••";
+let llmApiKeyIsSet = false;
 
 
 
@@ -176,6 +187,14 @@ if (aiApiKeyInput) {
       errorEl.style.display = "none";
     }
   });
+  // Focusing the stand-in selects it, so typing replaces the saved key in one go
+  // and backspacing clears the field — the two things the field can mean. Selecting
+  // is not editing, so simply clicking in and out still counts as untouched.
+  aiApiKeyInput.addEventListener("focus", () => {
+    if (llmApiKeyIsSet && aiApiKeyInput.value === SAVED_API_KEY_STANDIN) {
+      aiApiKeyInput.select();
+    }
+  });
 }
 
 // Per-provider endpoint/model defaults, read from the daemon (see llm.rs) so
@@ -250,9 +269,17 @@ function updateLlmProviderHints() {
   }
   if (apiKeyHint) {
     const local = baseUrlInput && isLoopbackUrl(baseUrlInput.value.trim());
-    apiKeyHint.innerText = local
-      ? "Not required for a local endpoint."
-      : "Stored in your OS keychain, never in a file and never sent to tenby10.";
+    if (local) {
+      apiKeyHint.innerText = "Not required for a local endpoint.";
+    } else if (llmApiKeyIsSet) {
+      apiKeyHint.innerText =
+        "A key is saved in your OS keychain. It is never read back into this window, " +
+        "so leave this field as it is to keep it, type a new key to replace it, or " +
+        "clear the field to delete it.";
+    } else {
+      apiKeyHint.innerText =
+        "Stored in your OS keychain, never in a file and never sent to tenby10.";
+    }
   }
 }
 
@@ -375,7 +402,8 @@ async function loadAgentConfig() {
       aiEngineToggle.checked = isLlm;
     }
     document.getElementById("ai-provider").value = currentConfig.llm_provider || "openai";
-    document.getElementById("ai-api-key").value = currentConfig.llm_api_key || "";
+    llmApiKeyIsSet = currentConfig.llm_api_key_set === true;
+    document.getElementById("ai-api-key").value = llmApiKeyIsSet ? SAVED_API_KEY_STANDIN : "";
     document.getElementById("ai-model").value = currentConfig.llm_model || "";
     document.getElementById("ai-base-url").value = currentConfig.llm_base_url || "";
     await loadLlmProviderDefaults();
@@ -461,8 +489,10 @@ if (saveSettingsBtn) {
     saveSettingsBtn.innerText = "Saving...";
 
     try {
-      // Re-fetch configuration to preserve SaaS credentials
-      const config = await invoke("get_agent_config");
+      // No re-fetch: the payload below carries only the fields this form owns, and
+      // the backend merges it into the stored configuration. Identity, the signing
+      // key and an untouched API key are preserved there, by never leaving there.
+      const config = {};
 
       // Evaluation Rules
       config.productive_apps = document.getElementById("rules-productive").value.trim();
@@ -478,7 +508,16 @@ if (saveSettingsBtn) {
 
       // AI Settings
       const isLlmEnabled = (aiEngineToggle && aiEngineToggle.checked);
-      const apiKey = document.getElementById("ai-api-key").value.trim();
+
+      // The API key field, read as an intention rather than a value (see
+      // SAVED_API_KEY_STANDIN). `null` means "send nothing, keep what is stored".
+      const apiKeyField = document.getElementById("ai-api-key").value;
+      const apiKeyUntouched = llmApiKeyIsSet && apiKeyField === SAVED_API_KEY_STANDIN;
+      const apiKeyUpdate = apiKeyUntouched ? null : apiKeyField.trim();
+      // Whether a key will be in place once this save lands — which is what the
+      // "AI needs a key" check has to ask, now that the field can be a stand-in.
+      const willHaveApiKey = apiKeyUntouched || apiKeyUpdate !== "";
+
       const prompt = document.getElementById("ai-prompt").value.trim();
       const baseUrl = document.getElementById("ai-base-url").value.trim();
       const model = document.getElementById("ai-model").value.trim();
@@ -499,7 +538,7 @@ if (saveSettingsBtn) {
           return;
         }
         // A local endpoint needs no key (Ollama ignores it); every remote one does.
-        if (!apiKey && !isLoopbackUrl(baseUrl)) {
+        if (!willHaveApiKey && !isLoopbackUrl(baseUrl)) {
           rejectSave("⚠️ API Key is required when AI Auditor is enabled.");
           return;
         }
@@ -540,17 +579,22 @@ if (saveSettingsBtn) {
 
       config.engine_mode = isLlmEnabled ? "llm" : "static";
       config.disable_work_summaries = !(summaryToggleEl && summaryToggleEl.checked);
-      if (summaryPromptEl) {
-        config.summary_prompt = summaryPromptText;
-      }
+      // Every field the payload carries is authoritative, so a missing textarea must
+      // resend what is stored rather than blank the prompt every note is signed against.
+      config.summary_prompt = summaryPromptEl ? summaryPromptText : (currentConfig.summary_prompt || "");
       config.llm_provider = document.getElementById("ai-provider").value;
-      config.llm_api_key = apiKey;
+      // Write-only: null keeps the stored key, "" deletes it, anything else replaces it.
+      config.llm_api_key = apiKeyUpdate;
       config.llm_base_url = baseUrl;
       config.llm_model = model;
       config.llm_prompt = prompt;
 
       await invoke("save_agent_config", { newConfig: config });
-      currentConfig = config;
+
+      // Re-read the redacted config so the form reflects what was actually stored,
+      // and so the API key field goes back to a stand-in rather than sitting there
+      // holding the key the user just typed.
+      await loadAgentConfig();
 
       saveSettingsBtn.innerText = "✓ Saved!";
       setTimeout(() => {


### PR DESCRIPTION
## TL;DR

- **The signing key no longer crosses IPC at all.** `get_agent_config` returns a redacted view with no `private_key` field and no API key value — only `llm_api_key_set: bool`. The API key is write-only: app → backend only.
- **`withGlobalTauri` is still on, deliberately.** Turning it off does not remove the IPC surface (`window.__TAURI_INTERNALS__.invoke` is injected regardless), and the dashboard iframe gets no Tauri injection at all, so it would force us to hand-roll a `window` bridge instead. Reasoning below — overrule me if you disagree.
- **To convince yourself the form still works:** Settings → AI Auditor. The API key field shows `••••••••••••••••` when a key is saved. Save without touching it, reopen — the key must still be there and the AI must still score. Then type a new key, save, reopen. Then clear the field with AI off, save — key gone.
- **CSP is real**, not decorative: `script-src 'self'` with no `unsafe-inline`, which meant rewiring the dashboard's 14 inline `onclick`s. `style-src` keeps `'unsafe-inline'` — both documents lay themselves out with `style=` attributes.

## Context

Three settings compounded. `tauri.conf.json` had `"csp": null` and `withGlobalTauri: true`, and `get_agent_config` returned the whole `AgentConfig` — Ed25519 signing key and BYOK API key, freshly overlaid from the keychain — into that webview, where the form held it in a variable and posted it all back on save.

No injection path exists today. This is about blast radius when one appears. Stealing the signing key means forging the ledger the product exists to sell.

There was also a live trap underneath it: `save_config` treats an empty secret as a keychain **delete**. The form only avoided wiping the signing key because it re-fetched the full config and round-tripped it. Removing the key from the response without fixing that would have destroyed signing identities.

## Changes

### 1. The signing key never crosses the boundary

`get_agent_config` → `RedactedAgentConfig`: no `private_key` field at all, no API key value, no `enrollment_token` (the form never showed it). `llm_api_key_set: bool` is what lets the form say "a key is saved".

`save_agent_config` now takes `AgentConfigUpdate` — only the ten fields the form owns, plus a write-only `llm_api_key: Option<String>` where `None` keeps, `Some("")` deletes, `Some(k)` replaces. It is merged into the configuration loaded from disk, so identity and secrets survive **because the payload cannot express them**, not because we remembered to copy them across.

**Judgement call:** the issue asked for a separate write-only *command*. I folded it into `save_agent_config` instead, because `save_config` validates prompts and can reject the whole save — two commands would break the "a save either lands whole or leaves the previous one untouched" property that `daemon/src/config.rs` documents and tests. `a_rejected_save_changes_no_secret` locks that in. Say the word and I will split it.

### 2. The delete bug

Two guards, both mutation-tested (I broke each one and confirmed the matching test fails, then restored):

- `apply_settings_update` merges into the **stored** config, so an absent secret is never an empty secret. → `a_save_without_secrets_leaves_the_keychain_intact`
- `ensure_agent_config_file` covers the edge I did not expect to find: `load_config` short-circuits to `AgentConfig::default()` when `config.json` is missing and, **on that path only, never consults the keychain**. So a settings save made while the file happened to be absent would have handed `save_config` an empty `private_key` and deleted a live signing key. Seeding an empty skeleton first sends the load down its normal overlay path. → `a_save_with_no_config_file_still_keeps_a_stored_signing_key`

**Constraint you should know about:** that second guard belongs in `daemon::config::load_config`, but `daemon/src/config.rs` is owned by another change in flight, so it is implemented on the desktop side with a comment saying so. Worth moving later.

The tests needed a keychain that actually remembers things. `keyring::mock` hands out a fresh empty credential per `Entry::new`, so a value written through one entry is invisible to the next — under it, "the key survived" would pass whether or not it did. There is a ~50-line in-process store in the test module instead, keyed by service + account like the real one. `keyring` is added as a **dev**-dependency only.

### 3. CSP

```
default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline';
img-src 'self' data:; font-src 'self'; connect-src ipc: http://ipc.localhost;
frame-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self';
frame-ancestors 'self'
```

Two loosenings, both load-bearing:

- **`style-src 'unsafe-inline'`** — unavoidable. `index.html` and `dashboard.html` position nearly everything with `style=` attributes, which CSP governs under `style-src`. Without it every hidden view renders at once. (Removing it would be its own PR: several hundred inline styles.)
- **`connect-src ipc: http://ipc.localhost`** — Tauri's IPC is a `fetch()` to `ipc://localhost/<cmd>`. This is the exact policy from Tauri's own docs. Note `'self'` is deliberately *not* in `connect-src`: the frontend makes no direct network calls of any kind, so same-origin XHR stays blocked too.

**`script-src 'self'` with no `unsafe-inline` is the part that cost work.** `dashboard.html` had 14 inline `on*` handlers, one `javascript:void(0)` href, and `dashboard.js` generated three more in template strings. Inline handlers cannot be nonced or hashed — only `'unsafe-inline'` enables them, and that would have made the whole directive decorative. So they are now `addEventListener` plus, for the re-rendered grids, `data-*` attributes read by one delegated listener. No behaviour change.

`dashboard.html` was not in the file list I was given, but this is not achievable without it.

### 4. `withGlobalTauri` — left on

Three reasons, in order of weight:

1. **It does not remove the IPC surface.** `tauri/src/manager/webview.rs` injects `window.__TAURI_INTERNALS__` unconditionally; `invoke` lives there and can call every registered command. `window.__TAURI__` is a convenience bundle over the same primitive. Dropping it removes a wrapper, not a capability.
2. **The dashboard runs in an iframe.** Tauri's init scripts are `for_main_frame_only: true`, so the iframe gets no injection — which is why `dashboard.js` already reaches through `window.parent.__TAURI__`. Without the global we would have to publish our own bridge on `window` for it: the same exposure, hand-rolled and unaudited.
3. **No bundler.** `frontendDist` points straight at `../src` with no build step, so `import { invoke } from '@tauri-apps/api/core'` needs either a bundler or the package's dist vendored into the repo behind an import map.

What actually bounds that surface now is the CSP: injected script cannot load, and cannot reach any host to send anything to. If you want `withGlobalTauri` gone anyway, it is a clean follow-up — say so and I will open one.

### 5. `AUDIT.md` G2

Rewritten to describe what shipped, including what did *not* close: the API key still crosses inbound (you have to type it somewhere) and `withGlobalTauri` is still on with the reason why. The one verdict-table row about keychain storage is updated; nothing else in the file is touched.

## Verification

`cargo fmt -- --check`, `cargo clippy -- -D warnings`, `cargo test` — clean on **both** crates (desktop 14 passed, daemon 122 passed). The pre-commit hook ran all six gates.

**I ran the real app** (`tauri dev`, `TENBY10_DEV=1`, isolated `TENBY10_HOME`). It builds, launches, and renders under the new CSP, and the status badge reads "Active" — that value comes from a live `invoke("get_agent_status")`, so **real Tauri IPC works under `connect-src ipc:`**. I could not click through its UI: driving the window needs an Accessibility grant this environment does not have (`osascript` returns `-25208`).

So I verified the interaction layer separately, and this is worth a paragraph because it is what most of my confidence rests on. I served the **byte-identical shipped** `main.js` / `dashboard.js` / CSS over HTTP with the **byte-identical CSP string** from `tauri.conf.json`, with a stub standing in for the Tauri bridge (the only difference in the HTML is one added `<script>` line). Under it:

- Zero console messages across both documents — no CSP violations anywhere.
- Negative controls confirm the policy is enforced, not merely present: injected inline `on*` handler blocked, injected inline `<script>` blocked, `fetch()` to a remote host blocked, `<img>` beacon to a remote host blocked, remote `<script src>` blocked. Inline style attributes still apply.
- Settings form: all three API-key intentions behave — untouched sends `llm_api_key: null` and the stored key survives; typed sends the new value and the field returns to the stand-in; saving twice in a row does not resend or wipe. Clearing the field with AI on and a remote endpoint is refused with the existing message; with AI off it sends `""`. The payload contains exactly the eleven `AgentConfigUpdate` fields and no `private_key`.
- Dashboard: every rewired control exercised — view tabs, prev/next day, date picker, "Today" (no `#` fragment), week-start select, export modal open/range-toggle/close, and all three delegated handlers (heatmap scroll-to, slot-details dialog, month-cell → daily + jump to date).

### What a reviewer still needs to click

The stub is not the real backend, so please confirm in the real app:

1. Settings → **Auditing Rules**: fields populate. Change one, Save, reopen — it stuck.
2. Settings → **AI Auditor** with a key already saved: the API key field shows `••••••••••••••••` and the hint explains the three behaviours. **Save without touching it, quit, relaunch — confirm a slot still scores** (that is the real proof the keychain entry survived, not just the boolean).
3. Type a new key → Save → reopen: field back to the stand-in, and scoring uses the new key.
4. Clear the field with the AI toggle **off** → Save → reopen: hint reverts to "Stored in your OS keychain…", `llm_api_key_set` is false.
5. **Enroll/re-pair after a settings save** — this is the one I most want a second pair of eyes on. `config_for_enrollment` reuses the stored keypair, so if a settings save had damaged `private_key` this is where it would surface as a fresh key and an orphaned ledger.
6. Dashboard: open it, switch monthly/weekly/daily, click a slot's **Details**, click a heatmap cell, click a month day cell, and run an **Export CSV** (the native save dialog is not covered by the harness).

## Not done, on purpose

- **`withGlobalTauri` left on** — reasoning above; this is the call most worth overruling.
- **`style-src 'unsafe-inline'` kept** — removing it means moving several hundred inline style attributes into the stylesheets. Wrong PR to do it in.
- **`daemon/src/config.rs` untouched** — the missing-`config.json` guard is implemented desktop-side instead, per the constraint on this task. It reads better in `load_config`.
- **Unrelated drift spotted, not fixed:** `desktop/package-lock.json` still says version `0.1.1` while `package.json` says `0.1.2`; `npm install` rewrites it. I reverted that hunk to keep this diff focused.

closes #94
