### PR TITLE
fix(desktop): stop the dashboard hanging when an AI provider is configured

### DIFF
--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -493,10 +493,27 @@ async fn dashboard_work_notes(
 /// only appears to people who would actually gain something by acting on it.
 #[tauri::command]
 async fn work_notes_enabled() -> Result<bool, String> {
-    let mut config_path = daemon::env::get_app_home();
-    config_path.push("config.json");
-    let config = daemon::config::load_config(config_path).unwrap_or_default();
-    Ok(!config.disable_work_summaries && daemon::llm::get_llm_provider(&config).is_some())
+    // Off the async runtime: `get_llm_provider` builds a `reqwest::blocking::Client`,
+    // which blocks waiting on its own runtime. Doing that inside a tokio context panics
+    // the worker mid-command, and Tauri then neither resolves nor rejects the call — so
+    // the dashboard's `await invoke('work_notes_enabled')` hung forever and every render
+    // and event handler behind it never ran (#107). Only reachable with a provider
+    // configured, since `get_llm_provider` returns early before building a client.
+    tokio::task::spawn_blocking(|| {
+        let mut config_path = daemon::env::get_app_home();
+        config_path.push("config.json");
+        let config = daemon::config::load_config(config_path).unwrap_or_default();
+        // The shared predicate, not a second copy of the rule. This one had drifted: it
+        // still omitted the engine-mode gate (#96), so it answered "notes on" for a
+        // `static` install that will never receive one.
+        daemon::daemon::work_notes_enabled(
+            &config.engine_mode,
+            config.disable_work_summaries,
+            daemon::llm::get_llm_provider(&config).is_some(),
+        )
+    })
+    .await
+    .map_err(|err| format!("work-notes check panicked: {err}"))
 }
 
 /// Classified minute-by-minute activity for a single 10-minute slot.
@@ -1453,5 +1470,47 @@ mod window_geometry_tests {
 
         assert_eq!(size, (1600, 1200));
         assert_centered_inside(size, position, chrome(2.0), area_position, area_size);
+    }
+}
+
+#[cfg(test)]
+mod blocking_boundary_tests {
+    /// #107: `get_llm_provider` builds a `reqwest::blocking::Client`, which blocks
+    /// waiting on its own runtime. Constructing one on the async runtime panics the
+    /// tokio worker mid-command, and Tauri then neither resolves nor rejects the
+    /// call — so the dashboard's `await invoke('work_notes_enabled')` hung forever
+    /// and every render and handler behind it never ran.
+    ///
+    /// This asserts the safe shape rather than the bug: the probe belongs on a
+    /// blocking thread. Written as a `#[tokio::test]` on purpose — the async
+    /// context is the whole point, and the same body called directly here would
+    /// reproduce the panic.
+    ///
+    /// Uses a loopback base URL so the provider resolves without an API key and
+    /// without reading the OS keychain, which would make this test prompt or hang
+    /// depending on the machine it runs on.
+    #[tokio::test]
+    async fn test_provider_probe_runs_off_the_async_runtime() {
+        let mut config = daemon::config::AgentConfig {
+            llm_provider: "openai".to_string(),
+            llm_base_url: "http://localhost:11434/v1".to_string(),
+            ..Default::default()
+        };
+        config.engine_mode = "llm".to_string();
+
+        let enabled = tokio::task::spawn_blocking(move || {
+            daemon::daemon::work_notes_enabled(
+                &config.engine_mode,
+                config.disable_work_summaries,
+                daemon::llm::get_llm_provider(&config).is_some(),
+            )
+        })
+        .await
+        .expect("the provider probe must not panic on a blocking thread");
+
+        assert!(
+            enabled,
+            "engine llm + a loopback provider + notes not disabled means notes are on"
+        );
     }
 }


### PR DESCRIPTION
## TL;DR

- With a BYOK provider configured, the Activity Dashboard never loaded: stuck on "Fetching database records..." with dead Prev/Next arrows. Found by running `main` locally.
- `work_notes_enabled` is an `async` command that builds a `reqwest::blocking::Client`, which panics inside tokio. Tauri then neither resolves nor rejects, so `dashboard.js` awaits a promise that never settles and everything behind it — the render and every handler — never runs.
- Fix: run the probe on a blocking thread, which the other seven commands in `lib.rs` already do. This was the only one that did not.
- **Not from this week's merges** — same shape at `v0.4.2` and `v0.5.0`. It only fires when a provider is configured, which is why it survived review and why it hit exactly the users who set up BYOK.

closes #107

## Context

Backtrace from `scripts/dev.sh` on `main` (`c060284`):

```
 9: reqwest::blocking::client::ClientHandle::new
11: reqwest::blocking::client::Client::new
12: daemon::llm::get_llm_provider          daemon/src/llm.rs:479
13: tenby10_desktop_lib::work_notes_enabled::{{closure}}
14: tauri::ipc::command::private::ResultFutureTag::future::{{closure}}
```

`reqwest::blocking::Client::new()` blocks waiting on its internal runtime. Inside an async context that panics with "Cannot drop a runtime in a context where blocking is not allowed", killing the tokio worker mid-command.

The frontend hang follows from that:

- `fetchDashboardData()` awaits `fetchWorkNotes()` (`dashboard.js:117`)
- `fetchWorkNotes()` awaits `invoke('work_notes_enabled')`, which never settles
- `processSlots()`, the render that replaces the placeholder, and all handler wiring sit after that line

The `try/catch` in `fetchWorkNotes` never fires, because there is no rejection — which is why nothing appeared in the console and it looked like a slow query.

`get_llm_provider` returns `None` before constructing a client when `llm_provider` is empty, so an install with no AI configured never reaches the panic.

## Changes

- Wrap the probe in `tokio::task::spawn_blocking`.
- Use the shared `daemon::daemon::work_notes_enabled` predicate instead of the copy inlined here. That copy had drifted and still omitted the engine-mode gate from #96, so it reported "notes on" for a `static` install that will never receive a note.
- Add a `#[tokio::test]` regression test. It is async on purpose — the async context is the thing under test. Loopback base URL so it resolves a provider without an API key and without touching the OS keychain, which would otherwise prompt or hang depending on the machine.

## Verification

`cargo fmt -- --check`, `cargo clippy -- -D warnings`, `cargo test` clean on both crates — desktop 14 → **15 passed**.

**Mutation-checked.** Removing the `spawn_blocking` from the test makes it fail with the original panic verbatim (`Cannot drop a runtime in a context where blocking is not allowed`); restoring it passes. The test has teeth.

Confirmed live: rebuilt under `tauri dev`, zero panics since.

## Follow-up, not in this PR

`enroll_agent`, `get_agent_status` and `get_agent_config` do keychain I/O directly on the async runtime. That stalls the runtime rather than panicking, so it is a real but much smaller problem than this one. Worth its own change.
