### PR TITLE
fix(daemon): stop a config save deleting a secret it was never given

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -386,11 +386,17 @@ real mismatches to close:
   limited to Tauri's own IPC scheme) — injected script cannot load, and cannot reach any remote
   host to send anything to.
 
-  One related failure was closed with it. `save_config` treats an empty secret as a keychain
-  *delete*, and the settings form used to avoid wiping the signing key only by re-fetching the
-  whole config and posting it back. Now that the form never receives it, `save_agent_config` takes
-  a payload that structurally cannot express a secret and merges it into the stored configuration,
-  so anything the form does not own is preserved by never leaving the backend. Locked by
+  One related failure was closed with it. `save_config` used to read an empty secret as a keychain
+  *delete*, and the settings form avoided wiping the signing key only by re-fetching the whole
+  config and posting it back. Now that the form never receives it, `save_agent_config` takes a
+  payload that structurally cannot express a secret and merges it into the stored configuration,
+  so anything the form does not own is preserved by never leaving the backend. The delete-by-
+  omission hazard underneath it is gone as well (#109): a secret left empty is one the caller is
+  not carrying, so `save_config` leaves the stored one alone, and removing one takes an explicit
+  `ClearSecrets` from the layer that knows the user emptied the field. `load_config` also overlays
+  the keychain when `config.json` is missing, rather than handing back a config with no secrets on
+  it. Locked by `a_save_cannot_delete_a_signing_key_it_never_received` and
+  `only_an_explicit_clear_removes_a_secret` ([config.rs](daemon/src/config.rs)), and by
   `a_save_without_secrets_leaves_the_keychain_intact` and
   `a_save_with_no_config_file_still_keeps_a_stored_signing_key`
   ([lib.rs](desktop/src-tauri/src/lib.rs)).

--- a/daemon/src/config.rs
+++ b/daemon/src/config.rs
@@ -280,10 +280,38 @@ fn keyring_service() -> String {
     }
 }
 
-/// Write a secret to the OS keychain. An empty value *deletes* any existing
-/// entry, so clearing a key in the UI actually removes it from the keychain
-/// rather than leaving a stale secret behind.
-fn store_secret(account: &str, value: &str) -> Result<(), String> {
+/// Which stored secrets a save is *explicitly* asked to remove.
+///
+/// [`save_config`] is handed a whole [`AgentConfig`], so an empty secret field on it
+/// means "this caller isn't carrying that secret" far more often than it means "the
+/// user deleted it". Reading the first as the second is how a settings save could
+/// destroy a live Ed25519 signing key and orphan every slot already signed under it
+/// (#109). So an empty field never deletes anything; removal has to be said out loud,
+/// here, by the one layer that actually knows the user asked for it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ClearSecrets {
+    pub private_key: bool,
+    pub llm_api_key: bool,
+}
+
+impl ClearSecrets {
+    /// Remove nothing — what a save means unless the user emptied the field themselves.
+    pub const NONE: Self = Self {
+        private_key: false,
+        llm_api_key: false,
+    };
+}
+
+/// Write a secret to the OS keychain.
+///
+/// A non-empty value is always written. An empty one is left alone unless `clear` says
+/// the caller means to delete it, in which case any existing entry is removed rather
+/// than left behind as a stale secret.
+fn store_secret(account: &str, value: &str, clear: bool) -> Result<(), String> {
+    if value.is_empty() && !clear {
+        // Not supplied. Say nothing to the keychain rather than destroy what is in it.
+        return Ok(());
+    }
     let entry = Entry::new(&keyring_service(), account)
         .map_err(|err| format!("Failed to open keychain entry '{}': {}", account, err))?;
     if value.is_empty() {
@@ -319,21 +347,27 @@ fn load_secret(account: &str) -> Result<String, String> {
 /// Load configuration from path. Returns default config if not found.
 ///
 /// Non-secret fields come from `config.json`; the `private_key` and
-/// `llm_api_key` secrets are overlaid from the OS keychain. Legacy config files
-/// that still hold plaintext secrets are transparently migrated into the
-/// keychain and rewritten without them.
+/// `llm_api_key` secrets are overlaid from the OS keychain — whether or not the
+/// file exists, since a missing `config.json` means "nothing configured yet",
+/// not "nothing stored anywhere". Legacy config files that still hold plaintext
+/// secrets are transparently migrated into the keychain and rewritten without them.
 pub fn load_config(config_path: PathBuf) -> Result<AgentConfig, String> {
-    if !config_path.exists() {
-        return Ok(AgentConfig::default());
-    }
-    // Startup reads this file, and a save may not happen for weeks, so a read is where
-    // an upgrade gets to fix the mode an older build left behind (#95).
-    crate::env::secure_app_home_for(&config_path);
-    crate::env::secure_file(&config_path);
-    let data = fs::read_to_string(&config_path)
-        .map_err(|err| format!("Failed to read config file: {}", err))?;
-    let mut config: AgentConfig = serde_json::from_str(&data)
-        .map_err(|err| format!("Failed to parse config file: {}", err))?;
+    // Falling through to the keychain overlay below rather than returning the
+    // defaults here is deliberate: a caller that loaded while the file was absent
+    // used to get a config carrying no secrets, and handing that back to
+    // `save_config` is what deleted stored ones (#109).
+    let mut config: AgentConfig = if config_path.exists() {
+        // Startup reads this file, and a save may not happen for weeks, so a read is where
+        // an upgrade gets to fix the mode an older build left behind (#95).
+        crate::env::secure_app_home_for(&config_path);
+        crate::env::secure_file(&config_path);
+        let data = fs::read_to_string(&config_path)
+            .map_err(|err| format!("Failed to read config file: {}", err))?;
+        serde_json::from_str(&data)
+            .map_err(|err| format!("Failed to parse config file: {}", err))?
+    } else {
+        AgentConfig::default()
+    };
 
     // Detect any legacy plaintext secrets still present in the file so we can
     // migrate them into the keychain below.
@@ -417,15 +451,30 @@ pub fn load_config(config_path: PathBuf) -> Result<AgentConfig, String> {
     Ok(config)
 }
 
-/// Save configuration to path.
+/// Save configuration to path, removing no stored secret.
 ///
 /// Secrets (`private_key`, `llm_api_key`) are written to the OS keychain; a
 /// sanitized copy of the config — with those fields blanked — is written to
 /// `config.json` so no secret ever lands in plaintext on disk.
 ///
+/// A secret left empty on `config` is one this caller is not carrying, and is left
+/// in the keychain untouched. Deleting one takes [`save_config_clearing`].
+///
 /// A configuration whose blobs the cloud would refuse is rejected before anything is
 /// written, so a save either lands whole or leaves the previous one untouched.
 pub fn save_config(config_path: PathBuf, config: &AgentConfig) -> Result<(), String> {
+    save_config_clearing(config_path, config, ClearSecrets::NONE)
+}
+
+/// [`save_config`], plus the secrets this save is deliberately removing.
+///
+/// Only a layer that knows the user emptied the field has any business passing
+/// anything but [`ClearSecrets::NONE`] here — see [`ClearSecrets`] for why.
+pub fn save_config_clearing(
+    config_path: PathBuf,
+    config: &AgentConfig,
+    clear: ClearSecrets,
+) -> Result<(), String> {
     config.validate()?;
 
     if let Some(parent) = config_path.parent() {
@@ -435,8 +484,8 @@ pub fn save_config(config_path: PathBuf, config: &AgentConfig) -> Result<(), Str
     crate::env::secure_app_home_for(&config_path);
 
     // Persist secrets to the OS keychain first.
-    store_secret(KR_PRIVATE_KEY, &config.private_key)?;
-    store_secret(KR_LLM_API_KEY, &config.llm_api_key)?;
+    store_secret(KR_PRIVATE_KEY, &config.private_key, clear.private_key)?;
+    store_secret(KR_LLM_API_KEY, &config.llm_api_key, clear.llm_api_key)?;
 
     // Serialize a sanitized copy so secrets never touch config.json.
     let mut on_disk = config.clone();
@@ -511,18 +560,92 @@ pub fn config_for_enrollment(config_path: PathBuf, enrollment_token: &str) -> Ag
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Once;
+    use std::collections::HashMap;
     use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::{Mutex, MutexGuard, Once};
 
-    static INIT_MOCK: Once = Once::new();
+    static INIT_KEYCHAIN: Once = Once::new();
     static COUNTER: AtomicU32 = AtomicU32::new(0);
+    /// The credential builder is process-wide, so its store is too. Serialise the
+    /// tests that touch it rather than let cargo's thread pool interleave one test's
+    /// save with another's assertion.
+    static KEYCHAIN: Mutex<()> = Mutex::new(());
+    static STORE: Mutex<Option<HashMap<String, Vec<u8>>>> = Mutex::new(None);
 
-    /// Route keychain access to the in-memory mock store so tests never touch
-    /// (or prompt for) the real OS keychain.
-    fn use_mock_keychain() {
-        INIT_MOCK.call_once(|| {
-            keyring::set_default_credential_builder(keyring::mock::default_credential_builder());
+    /// A stand-in keychain that actually remembers what was written to it.
+    ///
+    /// `keyring::mock` cannot be used here: it hands out a fresh, empty credential
+    /// per `Entry::new`, so a value written through one entry is invisible to the
+    /// next. Every assertion below about a secret *surviving* a save would then pass
+    /// whether or not it did. Telling "still there" from "deleted" needs real
+    /// persistence, keyed by service and account the way the OS keychain is.
+    #[derive(Debug)]
+    struct StoreCredential(String);
+
+    impl keyring::credential::CredentialApi for StoreCredential {
+        fn set_secret(&self, secret: &[u8]) -> keyring::Result<()> {
+            let mut store = STORE.lock().unwrap_or_else(|e| e.into_inner());
+            store
+                .get_or_insert_with(HashMap::new)
+                .insert(self.0.clone(), secret.to_vec());
+            Ok(())
+        }
+
+        fn get_secret(&self) -> keyring::Result<Vec<u8>> {
+            let store = STORE.lock().unwrap_or_else(|e| e.into_inner());
+            match store.as_ref().and_then(|s| s.get(&self.0)) {
+                Some(secret) => Ok(secret.clone()),
+                None => Err(keyring::Error::NoEntry),
+            }
+        }
+
+        fn delete_credential(&self) -> keyring::Result<()> {
+            let mut store = STORE.lock().unwrap_or_else(|e| e.into_inner());
+            match store.as_mut().and_then(|s| s.remove(&self.0)) {
+                Some(_) => Ok(()),
+                None => Err(keyring::Error::NoEntry),
+            }
+        }
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+
+    #[derive(Debug)]
+    struct StoreBuilder;
+
+    impl keyring::credential::CredentialBuilderApi for StoreBuilder {
+        fn build(
+            &self,
+            _target: Option<&str>,
+            service: &str,
+            user: &str,
+        ) -> keyring::Result<Box<keyring::Credential>> {
+            Ok(Box::new(StoreCredential(format!("{service}\u{0}{user}"))))
+        }
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+
+        fn persistence(&self) -> keyring::credential::CredentialPersistence {
+            keyring::credential::CredentialPersistence::ProcessOnly
+        }
+    }
+
+    /// Route keychain access to the in-process store so tests never touch — or
+    /// prompt for — the real OS keychain. Empties it first: the store outlives each
+    /// test, and a leftover secret would let one test satisfy another's assertion.
+    fn keychain() -> MutexGuard<'static, ()> {
+        INIT_KEYCHAIN.call_once(|| {
+            keyring::set_default_credential_builder(Box::new(StoreBuilder));
         });
+        let guard = KEYCHAIN
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        STORE.lock().unwrap_or_else(|e| e.into_inner()).take();
+        guard
     }
 
     /// A unique temp path per call so parallel tests don't collide on disk.
@@ -596,7 +719,7 @@ mod tests {
 
     #[test]
     fn test_save_config_writes_no_secrets_to_disk() {
-        use_mock_keychain();
+        let _keychain = keychain();
         let path = temp_config_path();
 
         let mut config = generate_enrollment_keys("tok");
@@ -624,9 +747,127 @@ mod tests {
         let _ = fs::remove_file(&path);
     }
 
+    /// The interlock (#109). `save_config` is handed a whole `AgentConfig`, and plenty
+    /// of callers assemble one without ever holding the signing key — a settings save
+    /// merging a form into a freshly loaded config, most of all. None of them may cost
+    /// the user that key: deleting it orphans every slot already signed under it, and
+    /// no re-pair brings it back.
+    #[test]
+    fn a_save_cannot_delete_a_signing_key_it_never_received() {
+        let _keychain = keychain();
+        let path = temp_config_path();
+
+        let enrolled = generate_enrollment_keys("tok");
+        save_config(path.clone(), &enrolled).expect("the baseline save should succeed");
+        assert_eq!(
+            load_secret(KR_PRIVATE_KEY).expect("the keychain should read"),
+            enrolled.private_key,
+            "the baseline save should have stored the signing key"
+        );
+
+        // A config carrying no secrets at all — exactly what a caller used to get back
+        // from `load_config` when `config.json` had gone missing.
+        let no_secrets = AgentConfig {
+            agent_id: enrolled.agent_id.clone(),
+            public_key: enrolled.public_key.clone(),
+            ..Default::default()
+        };
+        save_config(path.clone(), &no_secrets).expect("the save should succeed");
+
+        assert_eq!(
+            load_secret(KR_PRIVATE_KEY).expect("the keychain should read"),
+            enrolled.private_key,
+            "a save that was never given the signing key must not delete it"
+        );
+
+        let _ = fs::remove_file(&path);
+    }
+
+    /// The other end of the same hazard: a load with no `config.json` skipped the
+    /// keychain overlay entirely, so the caller never saw the secrets it was about to
+    /// write back out.
+    #[test]
+    fn a_missing_config_file_still_overlays_the_stored_secrets() {
+        let _keychain = keychain();
+        let path = temp_config_path();
+
+        let mut enrolled = generate_enrollment_keys("tok");
+        enrolled.llm_api_key = "sk-the-users-own-key".to_string();
+        save_config(path.clone(), &enrolled).expect("the baseline save should succeed");
+        fs::remove_file(&path).expect("the config file should exist to be removed");
+
+        let loaded = load_config(path.clone()).expect("load_config should succeed");
+        assert_eq!(
+            loaded.private_key, enrolled.private_key,
+            "a missing config.json must not hide the stored signing key"
+        );
+        assert_eq!(loaded.llm_api_key, enrolled.llm_api_key);
+        // Everything that lived only in the file is gone, as it should be.
+        assert!(loaded.agent_id.is_empty());
+
+        let _ = fs::remove_file(&path);
+    }
+
+    /// Removing a secret is still possible — it just has to be asked for by name, by
+    /// the one layer that knows the user emptied the field.
+    #[test]
+    fn only_an_explicit_clear_removes_a_secret() {
+        let _keychain = keychain();
+        let path = temp_config_path();
+
+        let mut enrolled = generate_enrollment_keys("tok");
+        enrolled.llm_api_key = "sk-the-users-own-key".to_string();
+        save_config(path.clone(), &enrolled).expect("the baseline save should succeed");
+
+        // The user cleared the API key field: that secret goes, the signing key stays.
+        let mut cleared = enrolled.clone();
+        cleared.llm_api_key = String::new();
+        save_config_clearing(
+            path.clone(),
+            &cleared,
+            ClearSecrets {
+                llm_api_key: true,
+                ..ClearSecrets::NONE
+            },
+        )
+        .expect("the save should succeed");
+        assert!(
+            load_secret(KR_LLM_API_KEY)
+                .expect("the keychain should read")
+                .is_empty(),
+            "an explicitly cleared API key must be removed"
+        );
+        assert_eq!(
+            load_secret(KR_PRIVATE_KEY).expect("the keychain should read"),
+            enrolled.private_key,
+            "clearing the API key must not touch the signing key"
+        );
+
+        // And the signing key itself, when that is what was asked for and nothing else.
+        let mut wiped = cleared.clone();
+        wiped.private_key = String::new();
+        save_config_clearing(
+            path.clone(),
+            &wiped,
+            ClearSecrets {
+                private_key: true,
+                ..ClearSecrets::NONE
+            },
+        )
+        .expect("the save should succeed");
+        assert!(
+            load_secret(KR_PRIVATE_KEY)
+                .expect("the keychain should read")
+                .is_empty(),
+            "an explicit clear is the one thing that removes the signing key"
+        );
+
+        let _ = fs::remove_file(&path);
+    }
+
     #[test]
     fn test_legacy_plaintext_config_is_migrated() {
-        use_mock_keychain();
+        let _keychain = keychain();
         let path = temp_config_path();
 
         // A pre-keychain config file that still holds plaintext secrets.
@@ -663,12 +904,12 @@ mod tests {
 
     #[test]
     fn test_config_for_enrollment_reuses_existing_keypair() {
-        use_mock_keychain();
+        let _keychain = keychain();
         let path = temp_config_path();
 
-        // An already-enrolled device. Keys are written inline so the reused values come from the
-        // file (the legacy-plaintext path takes precedence over the shared mock keychain slot),
-        // keeping the test deterministic under parallel runs.
+        // An already-enrolled device. Keys are written inline so the reused values come from
+        // the file rather than the keychain — the legacy-plaintext path takes precedence over
+        // the overlay — which pins what this test is about to the bytes right here.
         let existing = r#"{
             "agent_id": "agent_old",
             "enrollment_token": "first_token",
@@ -732,7 +973,7 @@ mod tests {
     /// save leaves the previous configuration intact rather than half-applied.
     #[test]
     fn test_save_config_rejects_oversized_prompts() {
-        use_mock_keychain();
+        let _keychain = keychain();
 
         for (field, mutate) in [
             (
@@ -766,7 +1007,7 @@ mod tests {
     /// will never accept stalls that hash chain permanently.
     #[test]
     fn test_load_config_falls_back_on_oversized_prompts() {
-        use_mock_keychain();
+        let _keychain = keychain();
         let path = temp_config_path();
 
         let huge = "x".repeat(MAX_PROMPT_BYTES + 1);
@@ -815,7 +1056,7 @@ mod tests {
 
     #[test]
     fn test_config_for_enrollment_generates_when_no_key_stored() {
-        use_mock_keychain();
+        let _keychain = keychain();
         let path = temp_config_path();
 
         // No config on disk yet (first-ever pair) → a fresh keypair is minted.

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -655,13 +655,17 @@ async fn get_agent_config() -> Result<RedactedAgentConfig, String> {
         .map(|config| RedactedAgentConfig::from(&config))
 }
 
-/// Fold a settings update into an already-loaded configuration.
+/// Fold a settings update into an already-loaded configuration, returning the
+/// secrets the user asked to delete.
 ///
 /// Everything absent from `update` is left exactly as it was, which is what keeps
 /// `private_key`, `agent_id`, `public_key` and `enrollment_token` intact across a
 /// save. `llm_api_key` is the one secret the form can write, and only when it
 /// actually says so.
-fn apply_settings_update(config: &mut daemon::config::AgentConfig, update: AgentConfigUpdate) {
+fn apply_settings_update(
+    config: &mut daemon::config::AgentConfig,
+    update: AgentConfigUpdate,
+) -> daemon::config::ClearSecrets {
     config.distracting_apps = update.distracting_apps;
     config.productive_apps = update.productive_apps;
     config.meeting_apps = update.meeting_apps;
@@ -672,48 +676,16 @@ fn apply_settings_update(config: &mut daemon::config::AgentConfig, update: Agent
     config.llm_prompt = update.llm_prompt;
     config.summary_prompt = update.summary_prompt;
     config.disable_work_summaries = update.disable_work_summaries;
+
+    let mut clear = daemon::config::ClearSecrets::NONE;
     if let Some(api_key) = update.llm_api_key {
-        // An empty string here is a deliberate delete — `save_config` clears the
-        // keychain entry for an empty secret. That is only ever reached when the
-        // user emptied the field on purpose; an untouched field sends `None`.
+        // This form is the only place that can tell an emptied field from an
+        // untouched one — an untouched field sends `None` — so it is the only place
+        // that may ask for a stored secret to be deleted.
+        clear.llm_api_key = api_key.is_empty();
         config.llm_api_key = api_key;
     }
-}
-
-/// Make sure `config.json` exists before a settings save reads it.
-///
-/// `load_config` short-circuits to `AgentConfig::default()` when the file is
-/// missing and — on that path only — never consults the OS keychain. Handing that
-/// default to `save_config` would pass an empty `private_key`, which `save_config`
-/// reads as "delete the keychain entry": a settings save made while the file
-/// happened to be absent would destroy a signing identity that was still sitting
-/// in the keychain, orphaning every slot already signed under it.
-///
-/// Seeding an empty skeleton first sends the load down its normal overlay path, so
-/// any stored secret comes back with it and is written straight back out. The
-/// skeleton carries no secrets and is exactly what `save_config` writes for a
-/// brand-new install, so this is a no-op on first run.
-///
-/// This guard belongs in `daemon::config::load_config`; it lives here because that
-/// file is owned by another change in flight (see the PR for #94).
-fn ensure_agent_config_file(config_path: &std::path::Path) -> Result<(), String> {
-    if config_path.exists() {
-        return Ok(());
-    }
-    if let Some(parent) = config_path.parent() {
-        std::fs::create_dir_all(parent)
-            .map_err(|err| format!("Failed to create config directory: {}", err))?;
-    }
-    // The four fields `AgentConfig` has no serde default for. Everything else fills
-    // in from the struct's own defaults.
-    let skeleton = serde_json::json!({
-        "agent_id": "",
-        "enrollment_token": "",
-        "public_key": "",
-        "private_key": "",
-    });
-    std::fs::write(config_path, skeleton.to_string())
-        .map_err(|err| format!("Failed to create config file: {}", err))
+    clear
 }
 
 /// Path-parameterised form of [`save_agent_config`], so the merge can be tested
@@ -722,10 +694,9 @@ fn save_agent_config_at(
     config_path: std::path::PathBuf,
     update: AgentConfigUpdate,
 ) -> Result<(), String> {
-    ensure_agent_config_file(&config_path)?;
     let mut config = daemon::config::load_config(config_path.clone())?;
-    apply_settings_update(&mut config, update);
-    daemon::config::save_config(config_path, &config)
+    let clear = apply_settings_update(&mut config, update);
+    daemon::config::save_config_clearing(config_path, &config, clear)
 }
 
 /// The endpoint and model each provider actually calls when the user leaves
@@ -1010,10 +981,11 @@ pub fn run() {
 }
 
 /// The settings form no longer sees the signing key, so nothing on the round trip
-/// can put it back. That makes these tests the only thing standing between a
-/// settings save and a destroyed signing identity: `save_config` treats an empty
-/// secret as a keychain *delete*, and a deleted signing key orphans every slot the
-/// ledger already carries. Read them as a safety interlock, not as coverage.
+/// can put it back: every save reaches `save_config` carrying whatever the load
+/// found, and a signing key lost on the way orphans every slot the ledger already
+/// carries. The daemon holds the guard that makes that safe (#109) — these tests
+/// check this crate's half, that a save asks to delete only what the user emptied.
+/// Read them as a safety interlock, not as coverage.
 #[cfg(test)]
 mod settings_save_tests {
     use super::{save_agent_config_at, AgentConfigUpdate, RedactedAgentConfig};
@@ -1179,9 +1151,11 @@ mod settings_save_tests {
         let _ = std::fs::remove_file(&path);
     }
 
-    /// `load_config` skips the keychain overlay entirely when `config.json` is
-    /// missing, so without the skeleton guard this exact sequence would hand
-    /// `save_config` an empty `private_key` and delete a live signing key.
+    /// A settings save made while `config.json` happens to be absent. `load_config`
+    /// used to skip the keychain overlay on that path, so this exact sequence handed
+    /// `save_config` an empty `private_key` and deleted a live signing key. Both ends
+    /// of that are fixed in the daemon now (#109); this holds the app-level behaviour
+    /// those two fixes exist for.
     #[test]
     fn a_save_with_no_config_file_still_keeps_a_stored_signing_key() {
         let _guard = keychain();


### PR DESCRIPTION
## Summary

Moves the signing-key guard from PR #106 down into `daemon/src/config.rs`, where the
hazard actually lives, and removes the desktop workaround it was standing in for.

The root cause was `save_config`'s "empty string means delete" contract. It takes a whole
`AgentConfig`, so an empty secret field means "this caller isn't carrying that secret" far
more often than it means "the user deleted it" — which made secret deletion the *default*
for any caller that assembled a config without the secret in hand. `load_config` was the
source of exactly such a config: it short-circuited to `AgentConfig::default()` when
`config.json` was missing and, on that early-return path only, skipped the keychain overlay.
A settings save made while the file happened to be absent destroyed the live Ed25519
signing key and orphaned every slot already signed under it.

Both ends are fixed:

* **`save_config` no longer blanks a secret it wasn't given.** An empty field is "not
  supplied" and leaves the stored secret alone. Deleting one takes the new
  `save_config_clearing(path, config, ClearSecrets { .. })`, so removal has to be said out
  loud by a layer that actually knows the user asked for it. `save_config` is now a thin
  wrapper passing `ClearSecrets::NONE`, so every existing caller gets the safe behaviour
  without a change.
* **`load_config` overlays the keychain whether or not `config.json` exists** — a missing
  file means "nothing configured yet", not "nothing stored anywhere". Worth having on its
  own: it is what stops a caller ever seeing a secretless config in the first place.

`desktop/src-tauri/src/lib.rs` is the one caller that can tell an emptied form field from an
untouched one (an untouched field sends `None`), so `apply_settings_update` now returns the
`ClearSecrets` it wants and `save_agent_config_at` passes it through. With the guard at the
hazard, `ensure_agent_config_file` — which seeded a skeleton `config.json` so the load took
its overlay path — is deleted along with its call site.

AUDIT.md's G2 note described the old "empty secret is a delete" semantics, so it is updated
to match.

## Testing

`cargo fmt -- --check`, `cargo clippy -- -D warnings` and `cargo test` are clean in both
`daemon/` (132 tests) and `desktop/src-tauri/` (15 tests). The pre-commit hook ran the same
sweep.

Three new daemon tests, all confirmed to fail against the pre-fix code rather than pass
vacuously:

* `a_save_cannot_delete_a_signing_key_it_never_received` — the interlock. Fails without the
  `store_secret` guard (`left: ""`, `right: <the stored key>`).
* `a_missing_config_file_still_overlays_the_stored_secrets` — the other end. Fails with the
  old early return restored.
* `only_an_explicit_clear_removes_a_secret` — deletion still works, for both secrets, when
  and only when it is asked for by name.

They needed a keychain that persists across `Entry::new`: `keyring::mock` hands out a fresh
empty credential per call, so every "the secret survived" assertion would pass whether or
not it did. The daemon test module now uses the same in-process store the desktop crate
already had, cleared per test and serialised behind a mutex since the credential builder is
process-wide. The six existing keychain tests were moved onto it unchanged.

The desktop test this whole thing exists for,
`a_save_with_no_config_file_still_keeps_a_stored_signing_key`, still passes — now because of
the daemon fix rather than the skeleton file.

## Notes for the reviewer

* `cargo clippy --all-targets` reports pre-existing errors in `daemon/src/{llm,daemon}.rs`
  and one `ptr_arg` in the desktop test helper `enrolled()`. All present on `main` and
  untouched here; CI runs the lib-target form, which is clean.
* `ClearSecrets::private_key` has no production caller — nothing in the app deletes a signing
  key. It is there so the type describes both secrets honestly rather than making one
  undeletable by omission, and `only_an_explicit_clear_removes_a_secret` exercises it.

closes #109
