### PR TITLE
feat(ai): specific auditor reasoning and work notes, prompt upgrade on load

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -39,7 +39,7 @@ auditable; the cloud portal is not part of this repository.
 | 6 | No image is sent to your LLM provider, ever | ✅ Verified structurally | The provider trait takes text only ([llm.rs](daemon/src/llm.rs)); nothing in the client can produce an image to send |
 | 7 | Focus-scoring rules are deterministic and inspectable | ✅ Verified | [evaluator.rs](daemon/src/evaluator.rs), [entropy.rs](daemon/src/entropy.rs) |
 | 8 | Local logs are tamper-evident (full-payload hash chain) + self-signed when enrolled | ✅ Verified | [db.rs `insert_slot_summary`/`verify_ledger_integrity`](daemon/src/db.rs) — work notes have their own chain, same construction (§5) |
-| 9 | Your daily work note describes the task, not the window title | ⚠️ Prompt-enforced, not mechanism-enforced | The default prompt ([config.rs:51](daemon/src/config.rs#L51)) tells the model never to quote a window title, file path, URL, or third-party name. Nothing inspects the sentence afterwards: `sanitize_note` ([llm.rs:108](daemon/src/llm.rs#L108)) rejects empty or essay-length replies, not leaked content. The prompt's SHA-256 is bound into the signed record so a reader can check which rules applied — that is evidence of the rule, not proof the model obeyed it |
+| 9 | Your daily work note names the work in its own words — never a verbatim window title, never a person | ⚠️ Mechanism-enforced for verbatim titles; prompt-steered for the rest | The default prompt ([config.rs:60](daemon/src/config.rs#L60)) instructs the model to name the project, document, or feature in its own words, and to reproduce no window title, file path, or URL verbatim and no person's name (ADR 0019 §4). The verbatim rule does not rest on the model: before a note is signed, `note_quotes_a_title` ([untrusted.rs](daemon/src/untrusted.rs), called from [daemon.rs:594](daemon/src/daemon.rs#L594)) refuses a note that echoes a ≥32-normalized-character run of any title captured that day, and `sanitize_note` ([llm.rs:108](daemon/src/llm.rs#L108)) rejects empty or essay-length replies. Short names (a repo, a product) pass the echo check by design. The person-name rule and the naming instruction remain prompt-steered; the prompt's SHA-256 is bound into the signed record so a reader can check which rules applied |
 | — | Secrets stored in OS keychain, and the signing key never reaches the app window | ✅ Verified | [config.rs `save_config`/`load_config`](daemon/src/config.rs) — `private_key` & `llm_api_key` kept in the OS keychain via the `keyring` crate. Since #94 the settings UI is sent a redacted config with no `private_key` and no API key value ([lib.rs](desktop/src-tauri/src/lib.rs)); the API key is write-only and the app runs under a `default-src 'self'` CSP — see G2 |
 | — | Local dashboard makes no third-party calls | ✅ Verified | [dashboard.rs](daemon/src/dashboard.rs) — Outfit font embedded as a data URI; no CDN `<link>` |
 | — | The installed app opens **no listening port** | ✅ Verified | The dashboard renders in-app over Tauri IPC. The loopback HTTP server is a debug-only escape hatch for the standalone `daemon` binary, off unless `TENBY10_DEBUG_HTTP` is set — [env.rs `debug_http_enabled`](daemon/src/env.rs) |
@@ -170,8 +170,10 @@ Nothing leaves the machine until you **enroll** and sync. The complete list of o
 
    Two different calls reach it, on two different conditions:
    - **Slot scoring** — only when `engine_mode == "llm"`
-     ([daemon.rs:794](daemon/src/daemon.rs#L794)). Payload: one line per minute of the slot with the
-     app name, the **window title**, and key/click counts.
+     ([daemon.rs:896](daemon/src/daemon.rs#L896)). Payload: one line per minute of the slot with its
+     local wall-clock time (HH:MM), the app name, the **window title**, key/click/scroll counts,
+     cursor travel in pixels, and the daemon's own rule-based state for that minute (#111). All of
+     it goes to the provider *you* configured; nothing new is sent to tenby10.
    - **Daily work note** — whenever a provider is configured and you have not opted out
      (`disable_work_summaries`, [daemon.rs:454-470](daemon/src/daemon.rs#L454)). Note this is **not**
      gated on `engine_mode`: connecting an AI is enough, by design (ADR 0019 — "setup once, then

--- a/daemon/src/config.rs
+++ b/daemon/src/config.rs
@@ -28,21 +28,30 @@ pub fn default_meeting_apps() -> String {
 pub fn default_llm_prompt() -> String {
     format!(
         "You are an AI productivity auditor. \
-        Review the following 10-minute activity log (containing apps, window titles, keystrokes, and clicks). \
+        Review the following 10-minute activity log. Each line is one minute: local time, app, \
+        window title, keystroke/click/scroll counts, mouse travel in pixels, and the daemon's own \
+        rule-based state for that minute. \
         Evaluate the user's focus on a scale of 0 to 100. \
         - Engineering, designing, writing, and active research are highly productive (80-100). \
         - Social media, entertainment, and casual browsing are distracted (0-30). \
         - A meeting with genuine engagement (e.g. Zoom, Teams) is productive; do NOT grant full focus to a completely inactive window merely because its title mentions a meeting app. \
+        - Scrolling or mouse travel without keystrokes usually means reading; no input and no travel means absence. \
         {} \
-        Output ONLY a JSON object with two fields: 'score' (integer) and 'reasoning' (1-2 sentences).",
+        Output ONLY a JSON object with two fields: 'score' (integer) and 'reasoning' (1-2 sentences). \
+        The reasoning is stored as this slot's explanation, so be concrete: name the work the \
+        titles show (project, document, or page) in your own words, and cite minute times for \
+        whatever moved the score (e.g. 'idle 08:42-08:47'). Never pad with generic filler like \
+        'focused work with brief idle moments'.",
         crate::untrusted::PROMPT_RULE
     )
 }
 
-/// Prompt for the daily work note (ADR 0019). Unlike the scoring prompt, whatever this
-/// produces is meant to be read by the client, so the constraints are the privacy
-/// mechanism: describe the task, never the window title, never a third party. There is
-/// no review step before it publishes, so the prompt is most of what keeps the note safe.
+/// Prompt for the daily work note (ADR 0019 §4). Whatever this
+/// produces is meant to be read by the client, and its value is that it names the work —
+/// the project, the document, the feature — in the model's own words. The constraints
+/// that remain are the privacy mechanism: never a verbatim window title, never a person.
+/// There is no review step before it publishes, so the prompt is most of what keeps the
+/// note safe.
 ///
 /// Most, not all: the no-quoting rule is also checked in code before a note is signed
 /// (#83, [`crate::untrusted::note_quotes_a_title`]), because a rule a client's privacy
@@ -53,16 +62,84 @@ pub fn default_summary_prompt() -> String {
         "You are writing a short work note that a client will read next to an invoice. \
         From the activity log below (apps and window titles), write one or two sentences \
         describing what was worked on, in plain professional language. \
-        - Describe the task, not the tools: \"reworked the checkout flow\", not \"was in VSCode\". \
-        - Never quote a window title, file path, or URL. A note that reproduces one is \
-        discarded unread and the day is left without a note. \
-        - Never name a person, company, or any third party. \
+        - Be specific: name the project, repository, document, or feature the titles show, and \
+        what was done to it — \"fixed the sync retries in the fleet-pilot repo and reviewed the \
+        billing pull request\", not \"worked on development tasks\". Name the work, not the tools \
+        it was done in. \
+        - Use your own words. Never reproduce a whole window title, file path, or URL verbatim: \
+        a note that does is discarded unread and the day is left without a note. \
+        - Never name a person. Projects, products, and companies are fine; people are not. \
         - Do not mention hours, focus scores, or productivity. \
         - If the activity is too unclear to describe honestly, say that plainly instead of guessing. \
         {} \
         Output ONLY the sentences, with no preamble.",
         crate::untrusted::PROMPT_RULE
     )
+}
+
+/// Every built-in auditor prompt this daemon ever shipped as the default, verbatim,
+/// oldest first — excluding the current one. Consumed only by `load_config`'s
+/// prompt-upgrade check (see the comment there). When `default_llm_prompt` changes,
+/// append the exact text it replaced here, or installs that saved settings under it
+/// keep scoring by the old rubric forever.
+fn retired_llm_prompts() -> [String; 2] {
+    [
+        // v1, initial import — before the untrusted-data rule existed (#83).
+        "You are an AI productivity auditor. \
+        Review the following 10-minute activity log (containing apps, window titles, keystrokes, and clicks). \
+        Evaluate the user's focus on a scale of 0 to 100. \
+        - Engineering, designing, writing, and active research are highly productive (80-100). \
+        - Social media, entertainment, and casual browsing are distracted (0-30). \
+        - A meeting with genuine engagement (e.g. Zoom, Teams) is productive; do NOT grant full focus to a completely inactive window merely because its title mentions a meeting app. \
+        Output ONLY a JSON object with two fields: 'score' (integer) and 'reasoning' (1-2 sentences)."
+            .to_string(),
+        // v2, #83..#111 — fence rule added; activity lines still untimed and the
+        // reasoning not yet required to be concrete.
+        format!(
+            "You are an AI productivity auditor. \
+            Review the following 10-minute activity log (containing apps, window titles, keystrokes, and clicks). \
+            Evaluate the user's focus on a scale of 0 to 100. \
+            - Engineering, designing, writing, and active research are highly productive (80-100). \
+            - Social media, entertainment, and casual browsing are distracted (0-30). \
+            - A meeting with genuine engagement (e.g. Zoom, Teams) is productive; do NOT grant full focus to a completely inactive window merely because its title mentions a meeting app. \
+            {} \
+            Output ONLY a JSON object with two fields: 'score' (integer) and 'reasoning' (1-2 sentences).",
+            crate::untrusted::PROMPT_RULE
+        ),
+    ]
+}
+
+/// The retired work-note prompts, mirror of [`retired_llm_prompts`].
+fn retired_summary_prompts() -> [String; 2] {
+    [
+        // v1, ADR 0019 initial — before the untrusted-data rule (#83).
+        "You are writing a short work note that a client will read next to an invoice. \
+        From the activity log below (apps and window titles), write one or two sentences \
+        describing what was worked on, in plain professional language. \
+        - Describe the task, not the tools: \"reworked the checkout flow\", not \"was in VSCode\". \
+        - Never quote a window title, file path, or URL. \
+        - Never name a person, company, or any third party. \
+        - Do not mention hours, focus scores, or productivity. \
+        - If the activity is too unclear to describe honestly, say that plainly instead of guessing. \
+        Output ONLY the sentences, with no preamble."
+            .to_string(),
+        // v2, #83..#111 — fence rule and the discard warning added; predates the
+        // ADR 0019 §4 revision that asks the note to name the work.
+        format!(
+            "You are writing a short work note that a client will read next to an invoice. \
+            From the activity log below (apps and window titles), write one or two sentences \
+            describing what was worked on, in plain professional language. \
+            - Describe the task, not the tools: \"reworked the checkout flow\", not \"was in VSCode\". \
+            - Never quote a window title, file path, or URL. A note that reproduces one is \
+            discarded unread and the day is left without a note. \
+            - Never name a person, company, or any third party. \
+            - Do not mention hours, focus scores, or productivity. \
+            - If the activity is too unclear to describe honestly, say that plainly instead of guessing. \
+            {} \
+            Output ONLY the sentences, with no preamble.",
+            crate::untrusted::PROMPT_RULE
+        ),
+    ]
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -397,6 +474,20 @@ pub fn load_config(config_path: PathBuf) -> Result<AgentConfig, String> {
         config.llm_prompt = default_llm_prompt();
     }
 
+    // A stored prompt equal to a retired built-in default was frozen there by an old
+    // save — `save_config` persists whole prompt strings — not chosen by the user, so
+    // an improved default would otherwise never reach any install that had opened
+    // Settings once (#111). Upgrade those in memory; a genuinely customized prompt
+    // matches none of the retired texts and is left exactly as written. The next slot
+    // then signs under the new config hash, which is the honest record: it is the
+    // rubric that actually scored it (#62).
+    if retired_llm_prompts().contains(&config.llm_prompt) {
+        config.llm_prompt = default_llm_prompt();
+    }
+    if retired_summary_prompts().contains(&config.summary_prompt) {
+        config.summary_prompt = default_summary_prompt();
+    }
+
     // Settings refuses to save an over-long prompt, but `config.json` can be edited by hand.
     // Signing a record against a blob the cloud will never accept stalls that hash chain for
     // good, so fall back to the built-in prompt rather than sign something unuploadable. The
@@ -658,6 +749,55 @@ mod tests {
             n
         ));
         path
+    }
+
+    /// A default prompt frozen into `config.json` by an old save upgrades to the
+    /// current default on load; a prompt the user actually wrote is never touched
+    /// (#111). Also pins the bookkeeping rule: the current defaults must not appear
+    /// in the retired lists.
+    #[test]
+    fn retired_default_prompts_upgrade_on_load_and_custom_ones_do_not() {
+        let _keychain = keychain();
+
+        assert!(!retired_llm_prompts().contains(&default_llm_prompt()));
+        assert!(!retired_summary_prompts().contains(&default_summary_prompt()));
+
+        for (retired_llm, retired_sum) in retired_llm_prompts()
+            .into_iter()
+            .zip(retired_summary_prompts())
+        {
+            let path = temp_config_path();
+            let json = serde_json::json!({
+                "agent_id": "a", "enrollment_token": "", "public_key": "", "private_key": "",
+                "llm_prompt": retired_llm,
+                "summary_prompt": retired_sum,
+            });
+            fs::write(&path, serde_json::to_string(&json).unwrap()).unwrap();
+            let loaded = load_config(path.clone()).expect("load_config should succeed");
+            assert_eq!(
+                loaded.llm_prompt,
+                default_llm_prompt(),
+                "a retired auditor default should upgrade"
+            );
+            assert_eq!(
+                loaded.summary_prompt,
+                default_summary_prompt(),
+                "a retired note default should upgrade"
+            );
+            let _ = fs::remove_file(&path);
+        }
+
+        let path = temp_config_path();
+        let json = serde_json::json!({
+            "agent_id": "a", "enrollment_token": "", "public_key": "", "private_key": "",
+            "llm_prompt": "My own rubric.",
+            "summary_prompt": "My own note style.",
+        });
+        fs::write(&path, serde_json::to_string(&json).unwrap()).unwrap();
+        let loaded = load_config(path.clone()).expect("load_config should succeed");
+        assert_eq!(loaded.llm_prompt, "My own rubric.");
+        assert_eq!(loaded.summary_prompt, "My own note style.");
+        let _ = fs::remove_file(&path);
     }
 
     #[test]

--- a/daemon/src/daemon.rs
+++ b/daemon/src/daemon.rs
@@ -695,6 +695,35 @@ fn meeting_creditable_ceiling(total_minutes: u32, demoted_meeting_minutes: u32) 
     ((creditable * 100) / 10).min(100)
 }
 
+/// Local wall-clock label (HH:MM) for a minute timestamp. The auditor is asked to
+/// cite these in its reasoning, so they must match the clock the user (and anyone
+/// reading the dashboard beside them) actually saw — hence local time, not UTC.
+fn minute_label(ts: i64) -> String {
+    use chrono::TimeZone;
+    chrono::Local
+        .timestamp_opt(ts, 0)
+        .single()
+        .map(|dt| dt.format("%H:%M").to_string())
+        .unwrap_or_else(|| ts.to_string())
+}
+
+/// One activity line for the slot auditor. App name and title are written by
+/// whoever owns the window, so both are scrubbed and the whole line rides inside
+/// the fence (#83); the time, the counts, and the state verdict are ours.
+fn format_activity_line(log: &crate::db::MinuteLogData, state: &str) -> String {
+    format!(
+        "[{}] App: '{}', Title: '{}', Keys: {}, Clicks: {}, Scrolls: {}, MouseTravel: {}px, State: {}",
+        minute_label(log.timestamp),
+        crate::untrusted::scrub(&log.active_app_name),
+        crate::untrusted::scrub(&log.active_window_title),
+        log.keystroke_count,
+        log.mouse_click_count,
+        log.scroll_event_count,
+        log.mouse_movement_distance.round() as i64,
+        state
+    )
+}
+
 pub fn aggregate_slot(db: &Database, config: &crate::config::AgentConfig, slot_start: i64) {
     let logs = match db.get_minute_logs_for_slot(slot_start) {
         Ok(logs) => logs,
@@ -724,6 +753,11 @@ pub fn aggregate_slot(db: &Database, config: &crate::config::AgentConfig, slot_s
     let mut was_recently_active = false;
     let mut consecutive_silent_meeting = 0u32;
     let mut demoted_meeting_minutes = 0u32;
+    // The final per-minute verdicts (after the silent-meeting demotion), in log
+    // order. The auditor sees these on each activity line: the daemon's own rule
+    // engine already classified every minute, and making the model re-derive that
+    // from raw counts produced vaguer reasoning, not independent judgment.
+    let mut minute_states: Vec<&'static str> = Vec::with_capacity(logs.len());
     let evaluator = crate::evaluator::ActivityEvaluator::new();
 
     for log in &logs {
@@ -756,6 +790,15 @@ pub fn aggregate_slot(db: &Database, config: &crate::config::AgentConfig, slot_s
         } else {
             consecutive_silent_meeting = 0;
         }
+
+        minute_states.push(match classification {
+            crate::evaluator::ActivityClassification::Active => "Active",
+            crate::evaluator::ActivityClassification::PassiveReview => "PassiveReview",
+            crate::evaluator::ActivityClassification::Meeting => "Meeting",
+            crate::evaluator::ActivityClassification::Idle => "Idle",
+            crate::evaluator::ActivityClassification::Distracted => "Distracted",
+            crate::evaluator::ActivityClassification::Tampered => "Tampered",
+        });
 
         let is_active = classification == crate::evaluator::ActivityClassification::Active
             || classification == crate::evaluator::ActivityClassification::PassiveReview
@@ -858,17 +901,8 @@ pub fn aggregate_slot(db: &Database, config: &crate::config::AgentConfig, slot_s
             let provider_opt = crate::llm::get_llm_provider(config);
             if let Some(provider) = provider_opt {
                 let mut activity_lines = Vec::new();
-                for log in &logs {
-                    // App name and title are both written by whoever owns the
-                    // window, so both are scrubbed and both ride inside the fence
-                    // (#83). The counts are ours.
-                    activity_lines.push(format!(
-                        "App: '{}', Title: '{}', Keys: {}, Clicks: {}",
-                        crate::untrusted::scrub(&log.active_app_name),
-                        crate::untrusted::scrub(&log.active_window_title),
-                        log.keystroke_count,
-                        log.mouse_click_count
-                    ));
+                for (log, state) in logs.iter().zip(minute_states.iter()) {
+                    activity_lines.push(format_activity_line(log, state));
                 }
                 let mut activity_text = crate::untrusted::fence(&activity_lines.join("\n"));
 
@@ -1014,6 +1048,36 @@ mod tests {
     use std::path::PathBuf;
     use std::sync::Arc;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    /// The auditor is only as concrete as its input (#111): every line must carry
+    /// the minute label, all three input counts, cursor travel, and the daemon's
+    /// own state verdict.
+    #[test]
+    fn activity_line_carries_time_counts_travel_and_state() {
+        let log = crate::db::MinuteLogData {
+            timestamp: 1_756_363_260,
+            keystroke_count: 94,
+            mouse_click_count: 3,
+            scroll_event_count: 12,
+            active_app_name: "Terminal".into(),
+            active_window_title: "ev-fleet-pilot — -zsh — 114×30".into(),
+            low_entropy: false,
+            mouse_movement_distance: 812.7,
+        };
+        let line = format_activity_line(&log, "Active");
+        assert!(
+            line.contains(
+                "] App: 'Terminal', Title: 'ev-fleet-pilot — -zsh — 114×30', Keys: 94, \
+                 Clicks: 3, Scrolls: 12, MouseTravel: 813px, State: Active"
+            ),
+            "unexpected line: {line}"
+        );
+        // The label is local wall-clock HH:MM — the times the reasoning will cite.
+        assert!(line.starts_with('['), "leads with the minute label: {line}");
+        let label = &line[1..line.find(']').unwrap()];
+        assert_eq!(label.len(), 5, "HH:MM label, got {label}");
+        assert_eq!(label.as_bytes()[2], b':');
+    }
 
     use std::sync::atomic::{AtomicUsize, Ordering};
     static DB_COUNTER: AtomicUsize = AtomicUsize::new(0);

--- a/daemon/src/db.rs
+++ b/daemon/src/db.rs
@@ -1545,7 +1545,7 @@ impl Database {
     pub fn get_minute_logs_for_slot(&self, slot_start: i64) -> Result<Vec<MinuteLogData>> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
-            "SELECT timestamp, keystroke_count, mouse_click_count, scroll_event_count, active_app_name, active_window_title, low_entropy 
+            "SELECT timestamp, keystroke_count, mouse_click_count, scroll_event_count, active_app_name, active_window_title, low_entropy, mouse_movement_distance 
              FROM minute_logs 
              WHERE timestamp >= ?1 AND timestamp < ?2
              ORDER BY timestamp ASC"
@@ -1560,6 +1560,7 @@ impl Database {
                 active_app_name: row.get(4)?,
                 active_window_title: row.get(5)?,
                 low_entropy: low_entropy_int != 0,
+                mouse_movement_distance: row.get(7)?,
             })
         })?;
 
@@ -1730,6 +1731,10 @@ pub struct MinuteLogData {
     pub active_app_name: String,
     pub active_window_title: String,
     pub low_entropy: bool,
+    /// Cursor travel this minute, in pixels. Already recorded per minute since v1;
+    /// surfaced here for the slot auditor, where travel with no clicks is the
+    /// difference between reading and absence.
+    pub mouse_movement_distance: f64,
 }
 
 /// A single 10-minute slot summary as shown in the activity dashboard.

--- a/daemon/src/untrusted.rs
+++ b/daemon/src/untrusted.rs
@@ -15,8 +15,10 @@
 //!      markers inside it; [`fence`] then wraps the assembled block in those
 //!      markers so the prompt can say where untrusted text starts and stops.
 //!   3. [`note_quotes_a_title`] refuses a finished note that reproduces a run of
-//!      a title verbatim — the prompt's "never quote a window title" rule,
-//!      enforced by the daemon instead of asked for.
+//!      a title verbatim — the prompt's "never reproduce a title verbatim" rule,
+//!      enforced by the daemon instead of asked for. (Short names — the
+//!      project, the document — belong in the note; the check only bites on
+//!      long runs, so specificity and the no-echo rule coexist. ADR 0019 §4.)
 //!
 //! **Honest limits.** A fence plus an instruction is a strong hint to a model,
 //! not a guarantee. This client is source-available, so anyone can read the
@@ -136,7 +138,7 @@ pub fn contains_fence_marker(text: &str) -> bool {
 /// Whether `note` reproduces at least [`MIN_ECHOED_TITLE_CHARS`] contiguous
 /// normalised characters of any of `titles`.
 ///
-/// This is the mechanical form of "never quote a window title". It is blunt on
+/// This is the mechanical form of "never reproduce a title verbatim". It is blunt on
 /// purpose: it cannot tell a leaked document name from a paraphrase that happened
 /// to land on six of the same words in the same order, and it refuses both. A
 /// refused note is left unwritten, which is the same honest failure as the AI


### PR DESCRIPTION
Closes #111.

## Summary

**What the auditor sees** — each activity line now carries the minute's local time, all three input counts, cursor travel in pixels, and the daemon's own rule-based state (after the silent-meeting demotion), so reasoning can reference specific minutes:

```
[08:41] App: 'Terminal', Title: 'ev-fleet-pilot — -zsh — 114×30', Keys: 0, Clicks: 0, Scrolls: 0, MouseTravel: 0px, State: Idle
```

**What the prompts ask for** — the auditor's reasoning should name the concrete work and cite minute times for whatever moved the score. The work note names the project, repository, document, or feature in its own words (ADR 0019 §4). Unchanged and still enforced in code: no verbatim reproduction of a title/path/URL (`note_quotes_a_title` echo check), no person names, no hours/scores in prose.

**Why installs pick this up** — `save_config` persists whole prompt strings, so an install that saved settings keeps the default prompt of that era. `load_config` now upgrades a stored prompt that matches a retired built-in default (both historical generations reconstructed byte-identically, pinned by test); customized prompts match nothing and are untouched. The next slot signs under the new config hash, per the config-in-ledger rule.

**AUDIT.md, same PR** — §2's BYOK payload inventory covers the new per-minute fields (all of it to the provider *you* configure; nothing new to tenby10), and row 9 describes the current note rules together with the echo check that has run before signing since #83.

## Tests

Retired-default upgrade + custom-prompt preservation; activity-line format. Full suite: 134 daemon + 15 desktop, green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)