### PR TITLE
docs: make AUDIT.md's decision-record citations resolvable

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -18,6 +18,11 @@ prove) it. Every reference is `file:line` and is meant to be opened and read dir
 this document's word for it. The `## How to verify` section at the bottom gives grep recipes so you
 can re-derive every claim yourself.
 
+A reference like "ADR 0018" names a numbered decision record in the project's internal decision log.
+Those records say *why* a design choice was made; they are not part of this repository, and are
+available on request. Nothing here rests on them — every claim below is proven by the code
+references, which are all in this repository.
+
 This client is **source-available** under the PivotalPoint Source-Available License, Version 1.0
 (PPSAL-1.0 — see [LICENSE](LICENSE)) — the full client that runs on your machine is readable and
 auditable; the cloud portal is not part of this repository.
@@ -55,9 +60,8 @@ say how far it goes. Opt-in BYOK inference sends activity text (window titles in
 the provider *you* configure — fully on-device with local Ollama.
 
 The gap previously logged here as **G1** (a `send_screenshots` toggle that never sent anything) is
-closed: rather than wire it up, the screenshot subsystem was removed outright
-([ADR 0018](../decisions/0018-remove-screenshot-subsystem.md)). The toggle is gone, and so is every
-line of capture code.
+closed: rather than wire it up, the screenshot subsystem was removed outright (ADR 0018). The toggle
+is gone, and so is every line of capture code.
 
 ---
 
@@ -122,9 +126,9 @@ Nothing leaves the machine until you **enroll** and sync. The complete list of o
      keystroke/click **counts**, app-category **counts**, a SHA-256 **hash** of the LLM reasoning
      (not the text), the effective-config hash, and the hash-chain link + Ed25519 signature.
    - **Signed daily work notes** (`summary_payload`, [sync.rs:168](daemon/src/sync.rs#L168),
-     `POST /api/v1/summaries`, [ADR 0019](../decisions/0019-worker-controlled-summary-sharing.md),
-     shipped 2026-08-14): one or two sentences per finished local day, **as text**. This is the only
-     upload that carries prose rather than counts and hashes.
+     `POST /api/v1/summaries`, ADR 0019, shipped 2026-08-14): one or two sentences per finished
+     local day, **as text**. This is the only upload that carries prose rather than counts and
+     hashes.
      Fields: `agent_id`, `scheme_version`, `period_start`, `period_end`, `generated_at`,
      `revision`, `summary_text` (the note itself), `prompt_hash` (SHA-256 of the prompt that wrote
      it), `ledger` (`hash` + `parent_hash`), `signature`. The note is written on your machine by
@@ -218,9 +222,8 @@ ls ~/.tenby10/screenshots 2>/dev/null      # removed on upgrade; never recreated
 ```
 
 Earlier versions (≤ v0.2.x) captured one heavily-blurred JPEG per 10-minute slot and kept it locally,
-never uploading it. That subsystem was deleted rather than left switchable — see
-[ADR 0018](../decisions/0018-remove-screenshot-subsystem.md) — and the first run of a current build
-deletes the old `~/.tenby10/screenshots/` folder
+never uploading it. That subsystem was deleted rather than left switchable — see ADR 0018 — and the
+first run of a current build deletes the old `~/.tenby10/screenshots/` folder
 ([env.rs `purge_legacy_screenshots`](daemon/src/env.rs)).
 
 **Why macOS still asks for Screen Recording.** The app reads *window titles*, and macOS withholds
@@ -233,8 +236,7 @@ held for text metadata, not pixels. The settings page reports whether titles are
 ## 4. Are the scoring rules fair?
 
 All classification is isolated in one pure module so it can be read and unit-tested without the
-capture loop ([decisions/0002](../decisions/0002-activity-evaluation-engine.md)). A minute is sorted
-into exactly one state by a fixed priority order in
+capture loop (ADR 0002). A minute is sorted into exactly one state by a fixed priority order in
 [evaluator.rs:114-167](daemon/src/evaluator.rs#L114):
 
 1. **Anti-cheat first** — mouse jiggler or keyboard macro → `Tampered`
@@ -275,9 +277,9 @@ and bias toward never flagging a real person:
 
 **Scoring is deterministic and forgiving of thinking time:**
 - Fixed 10-minute denominator so you can't game a 100% off one active minute
-  ([daemon.rs:785-786](daemon/src/daemon.rs#L785), [decisions/0006](../decisions/0006-focus-score-fixed-denominator.md)).
+  ([daemon.rs:785-786](daemon/src/daemon.rs#L785), ADR 0006).
 - 5-minute delayed "idle forgiveness" for reading/thinking pauses at slot boundaries
-  ([daemon.rs:727-783](daemon/src/daemon.rs#L727), [decisions/0011](../decisions/0011-contextual-idle-forgiveness.md)).
+  ([daemon.rs:727-783](daemon/src/daemon.rs#L727), ADR 0011).
 
 **The rules are locked by tests** — read these to see the intended behavior as executable spec:
 - [evaluator.rs:223-459](daemon/src/evaluator.rs#L223) — active / passive / idle / distraction / jiggler.
@@ -365,8 +367,7 @@ real mismatches to close:
 
 - **G1 — CLOSED (removed, not fixed).** A `send_screenshots` toggle used to imply a multimodal
   data flow that was never wired up. Instead of implementing it, the whole screenshot subsystem was
-  deleted ([ADR 0018](../decisions/0018-remove-screenshot-subsystem.md)): no toggle, no capture code,
-  no image path to any provider. See §3.
+  deleted (ADR 0018): no toggle, no capture code, no image path to any provider. See §3.
 
 - **G2 — CLOSED for the signing key; narrowed for the API key (#94).** `private_key` and
   `llm_api_key` live in the OS keychain and `config.json` is written sanitized with those fields


### PR DESCRIPTION
## TL;DR

AUDIT.md linked to decision records seven times using paths that point outside this repository, so
all seven 404'd on GitHub — in the document whose premise is "open every reference and check for
yourself".

The records stay internal. The seven links become plain citations, matching the three references in
the document that already read that way, plus one short paragraph near the top saying what a
decision record is and that it can be had on request.

Docs only, one file, no code touched.

## Context

`decisions/` sits above this repository in the working tree, so `../decisions/…` resolved on a
maintainer's machine and nowhere else.

Three citations in AUDIT.md were already written without links — verdict row 3, the work-note item
in §2, and verify recipe 6 — so this makes the document consistent with a convention it was already
half using, rather than introducing one.

## What changes

- The seven `../decisions/…` links become plain citations: `(ADR 0018)`, `ADR 0019`, `(ADR 0002)`,
  `ADR 0006`, `ADR 0011`.
- One new paragraph after the "how to read this guide" lines: a reference like "ADR 0018" names a
  record in the project's internal decision log, those records say *why* a choice was made, they are
  not part of this repository and are available on request, and nothing here rests on them — every
  claim is proven by the code references, which are all in this repository.
- Four paragraphs reflowed where a long link became a short citation. No wording changed in them.

No claim, row, verdict or verification recipe changes.

## Verification

- No `](../` links remain anywhere in AUDIT.md; every relative link in the file resolves to a
  path tracked in this repository.
- Docs-only change; `cargo fmt`, `cargo clippy -- -D warnings` and `cargo test` green in both
  `daemon` and `desktop/src-tauri` via the pre-commit hook.

closes #115
