### PR TITLE
feat(debrief): private daily debrief with gap-scaled explanation

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -40,7 +40,7 @@ auditable; the cloud portal is not part of this repository.
 | 2 | Only counts/metadata are stored per minute | ✅ Verified | [daemon.rs:414](daemon/src/daemon.rs#L414), [db.rs schema](daemon/src/db.rs) |
 | 3 | No screen capture exists at all | ✅ Verified | No capture code in the client (ADR 0018) — §3 has the grep and names the two lookalike symbols it deliberately excludes |
 | 4 | Raw keystrokes never leave the machine; **raw** window titles never reach tenby10 | ⚠️ Verified, but narrowed on 2026-08-14 | Still true of raw titles: no upload payload has a title field ([sync.rs:85](daemon/src/sync.rs#L85), [sync.rs:168](daemon/src/sync.rs#L168), [sync.rs:185](daemon/src/sync.rs#L185)). What changed: a title-*derived* sentence now does reach tenby10, in the daily work note (§2) — row 9 is what constrains it. Raw titles still go only to your own BYOK provider (row 5) |
-| 5 | Cloud sync (when enrolled) is count/category summaries + hashes + config + your daily work notes; your BYOK provider is the only other destination | ✅ Verified, scope corrected | Five endpoints, all inventoried in §2 — [sync.rs](daemon/src/sync.rs). BYOK calls live in [llm.rs](daemon/src/llm.rs), reached from slot scoring ([daemon.rs:794](daemon/src/daemon.rs#L794)) and from note writing ([daemon.rs:454](daemon/src/daemon.rs#L454)) |
+| 5 | Cloud sync (when enrolled) is count/category summaries + hashes + config + your daily work notes; your BYOK provider is the only other destination | ✅ Verified, scope corrected | Five endpoints, all inventoried in §2 — [sync.rs](daemon/src/sync.rs). BYOK calls live in [llm.rs](daemon/src/llm.rs), reached from slot scoring, note writing, and debrief writing (`generate_pending_debriefs`, [daemon.rs](daemon/src/daemon.rs)); the debrief's output stays local (§1a) |
 | 6 | No image is sent to your LLM provider, ever | ✅ Verified structurally | The provider trait takes text only ([llm.rs](daemon/src/llm.rs)); nothing in the client can produce an image to send |
 | 7 | Focus-scoring rules are deterministic and inspectable | ✅ Verified | [evaluator.rs](daemon/src/evaluator.rs), [entropy.rs](daemon/src/entropy.rs) |
 | 8 | Local logs are tamper-evident (full-payload hash chain) + self-signed when enrolled | ✅ Verified | [db.rs `insert_slot_summary`/`verify_ledger_integrity`](daemon/src/db.rs) — work notes have their own chain, same construction (§5) |
@@ -102,10 +102,17 @@ Written once per 60s at [daemon.rs:414-423](daemon/src/daemon.rs#L414):
 The one genuinely sensitive field is `active_window_title` (it can contain document names, email
 subjects, URLs). It is captured via [daemon.rs:197-215](daemon/src/daemon.rs#L197)
 (`active-win-pos-rs`) and stored **locally**. The title itself only leaves the machine if you connect
-your own AI, and then it goes to *your* provider — for slot scoring, and for writing the daily work
-note (§2). It is **never** a field in anything uploaded to tenby10. What tenby10 does receive is the
-work note: a sentence written *from* titles, which is a weaker boundary than "no title ever travels"
-and is stated as such in rows 4 and 9.
+your own AI, and then it goes to *your* provider — for slot scoring, for writing the daily work
+note, and for the private daily debrief (§2). It is **never** a field in anything uploaded to
+tenby10. What tenby10 does receive is the work note: a sentence written *from* titles, which is a
+weaker boundary than "no title ever travels" and is stated as such in rows 4 and 9.
+
+**§1a. The private daily debrief table.** `daily_debriefs` (#113) stores one local-only record per
+day: a narrative paragraph written by *your* AI, the day's category arithmetic, and the day's
+episode list (spans, apps, titles, states). It is worker-facing by construction: the table has no
+hash, no signature and no sync flag, nothing in [sync.rs](daemon/src/sync.rs) reads it, and the
+only reader is the dashboard. Rows expire after 30 days unless explicitly kept
+(`prune_expired_debriefs`, [db.rs](daemon/src/db.rs)).
 
 ---
 
@@ -182,11 +189,21 @@ Nothing leaves the machine until you **enroll** and sync. The complete list of o
      (`disable_work_summaries`, [daemon.rs:454-470](daemon/src/daemon.rs#L454)). Note this is **not**
      gated on `engine_mode`: connecting an AI is enough, by design (ADR 0019 — "setup once, then
      invisible"). Payload: the day's activity digest (`activity_digest`,
-     [db.rs:1308](daemon/src/db.rs#L1308)) — up to 60 `"12m — App: Window title"` lines, drawn only
-     from slots that cleared the focus bar and only from minutes with real input, so an unbilled
-     personal browse never reaches the model.
+     [db.rs](daemon/src/db.rs)) — up to 60 chronological runs of the form
+     `"09:10–09:52 (42m) — App: Window title"` (#113), drawn only from slots that cleared the
+     focus bar and only from minutes with real input, so an unbilled personal browse never
+     reaches the model.
+   - **Private daily debrief** (#113) — when the AI engine is on and a provider is configured
+     (`generate_pending_debriefs`, [daemon.rs](daemon/src/daemon.rs)). Payload: the day's episode
+     lines (span, app, **window title**, counts, state), *unfiltered by billability* — this feeds
+     a document that never leaves the machine (§1a). On an ordinary day the Distracted and Idle
+     episodes are withheld from the request entirely; they are included only when the day's
+     credited time falls well below presence (`debrief::needs_reconciliation`,
+     [debrief.rs](daemon/src/debrief.rs)), which is also the only case where titles from
+     distracting apps reach the provider. The output is stored locally, is never uploaded, and
+     expires after 30 days unless kept.
 
-   Text only in both cases; no image exists to send (§3).
+   Text only in all three cases; no image exists to send (§3).
 
 3. **Dashboard webfont — self-hosted.** The dashboard font is embedded as a `data:` URI
    ([dashboard.rs](daemon/src/dashboard.rs)); opening the local dashboard makes **no** third-party

--- a/daemon/src/config.rs
+++ b/daemon/src/config.rs
@@ -77,6 +77,32 @@ pub fn default_summary_prompt() -> String {
     )
 }
 
+/// Prompt for the private daily debrief (#113). Not a field of [`AgentConfig`] and
+/// not part of the signed config blob, on purpose: the debrief never affects a
+/// score and never leaves the machine, so there is no rubric to attest to — and
+/// keeping it out of the blob keeps "what the score was computed under" exactly
+/// as small as it was.
+pub fn debrief_prompt() -> String {
+    format!(
+        "You are writing a private end-of-day debrief that only the person who did the work will \
+        read. From the episode log below (one line per stretch of the day), write one paragraph of \
+        four to eight sentences describing the day in plain, neutral language. \
+        - Name the work: the projects, documents, or features the titles show, in your own words, \
+        and how the day was shaped — long focus stretches, fragmentation, interruptions, breaks. \
+        - Describe, never prescribe: no advice, no judgment, no praise or blame. Report what \
+        happened. \
+        - If episodes marked Distracted or Idle are present, account for that time matter-of-factly, \
+        and judge those episodes by their titles rather than their labels — if a 'Distracted' \
+        episode's titles look related to the work, say so. \
+        - If no Distracted or Idle episodes are present, do not speculate about gaps. \
+        - Cite times of day when they help (e.g. 'from 14:10'). Do not restate total hours — the \
+        numbers are shown separately. \
+        {} \
+        Output ONLY the paragraph, with no preamble.",
+        crate::untrusted::PROMPT_RULE
+    )
+}
+
 /// Every built-in auditor prompt this daemon ever shipped as the default, verbatim,
 /// oldest first — excluding the current one. Consumed only by `load_config`'s
 /// prompt-upgrade check (see the comment there). When `default_llm_prompt` changes,

--- a/daemon/src/daemon.rs
+++ b/daemon/src/daemon.rs
@@ -314,7 +314,10 @@ pub fn start_daemon_loop(db: Arc<Database>, state: Arc<TelemetryState>) {
     // never delays the first telemetry minute.
     {
         let db_clone = db.clone();
-        thread::spawn(move || generate_pending_summaries(&db_clone));
+        thread::spawn(move || {
+            generate_pending_summaries(&db_clone);
+            generate_pending_debriefs(&db_clone);
+        });
     }
 
     loop {
@@ -430,9 +433,11 @@ pub fn start_daemon_loop(db: Arc<Database>, state: Arc<TelemetryState>) {
         let db_clone = db.clone();
         thread::spawn(move || {
             aggregate_pending_slots(&db_clone);
-            // Off the same beat, and off the main thread: writing a note calls the
-            // user's own AI over the network, which must never stall telemetry.
+            // Off the same beat, and off the main thread: writing a note or a
+            // debrief calls the user's own AI over the network, which must never
+            // stall telemetry.
             generate_pending_summaries(&db_clone);
+            generate_pending_debriefs(&db_clone);
         });
 
         // Reset counts for the next minute segment
@@ -472,6 +477,171 @@ pub fn work_notes_enabled(
     has_provider: bool,
 ) -> bool {
     engine_mode == "llm" && !disable_work_summaries && has_provider
+}
+
+/// A day's debrief inputs, assembled and ready for the model (#113). Split from
+/// the network call so the assembly — episode building, the reconciliation
+/// switch, what does and does not reach the prompt — is testable without a
+/// provider.
+struct PreparedDebrief {
+    activity_text: String,
+    accounting: crate::debrief::DayAccounting,
+    reconciliation: bool,
+    episodes_json: String,
+}
+
+/// Classify each minute of a day with the same rules the slots were scored
+/// under, minus billing-only adjustments (the silent-meeting demotion bounds
+/// credit; it does not describe a day).
+fn classify_day_minutes(
+    logs: &[crate::db::MinuteLogData],
+    config: &crate::config::AgentConfig,
+) -> Vec<&'static str> {
+    let evaluator = crate::evaluator::ActivityEvaluator::new();
+    let mut was_recently_active = false;
+    logs.iter()
+        .map(|log| {
+            let ctx = crate::evaluator::StoredEvaluationContext {
+                keystroke_count: log.keystroke_count,
+                mouse_click_count: log.mouse_click_count,
+                scroll_event_count: log.scroll_event_count,
+                active_app: &log.active_app_name,
+                active_title: &log.active_window_title,
+                low_entropy: log.low_entropy,
+                was_recently_active,
+                distracting_apps: &config.distracting_apps,
+                productive_apps: &config.productive_apps,
+                meeting_apps: &config.meeting_apps,
+            };
+            let c = evaluator.evaluate_stored_minute(&ctx);
+            was_recently_active = c == crate::evaluator::ActivityClassification::Active;
+            state_name(c)
+        })
+        .collect()
+}
+
+/// Assemble one day's debrief inputs, or `None` when the day has nothing worth
+/// a paragraph. The reconciliation switch decides here — not in the renderer —
+/// whether Distracted/Idle episodes reach the model at all: on an ordinary day
+/// they are absent from the prompt, not merely hidden from the page.
+fn prepare_debrief_inputs(
+    db: &Database,
+    config: &crate::config::AgentConfig,
+    day_start: i64,
+    day_end: i64,
+) -> Option<PreparedDebrief> {
+    let categories = db.day_category_minutes(day_start, day_end).ok()?;
+    let accounting = crate::debrief::DayAccounting::from_category_minutes(&categories);
+    if accounting.presence < DEBRIEF_MIN_PRESENCE_MINUTES {
+        return None;
+    }
+    let logs = db.minute_logs_in_period(day_start, day_end).ok()?;
+    if logs.is_empty() {
+        return None;
+    }
+    let states = classify_day_minutes(&logs, config);
+    let episodes = crate::debrief::build_episodes(&logs, &states, &config.distracting_apps);
+    let reconciliation = crate::debrief::needs_reconciliation(&accounting);
+    let lines = crate::debrief::digest_lines(&episodes, reconciliation);
+    if lines.is_empty() {
+        return None;
+    }
+
+    // The episode lines are captured text and ride inside the fence; the
+    // accounting sentence after it is the daemon speaking, kept separable on
+    // purpose (#83).
+    let mut activity_text = crate::untrusted::fence(&lines.join("\n"));
+    activity_text.push_str(&format!(
+        "\n\nDAY ACCOUNTING (computed by the daemon): {}.",
+        crate::debrief::format_accounting_line(&accounting)
+    ));
+    if reconciliation {
+        activity_text.push_str(
+            " Credited time was well below time at the computer, so the log above includes \
+             the Distracted and Idle episodes; account for where that time went.",
+        );
+    } else {
+        activity_text.push_str(
+            " This was an ordinary day; off-work episodes are not included in the log above. \
+             Do not speculate about gaps.",
+        );
+    }
+
+    Some(PreparedDebrief {
+        activity_text,
+        accounting,
+        reconciliation,
+        episodes_json: serde_json::to_string(&episodes).unwrap_or_else(|_| "[]".into()),
+    })
+}
+
+/// Write the private daily debrief for any finished local day that lacks one
+/// (#113), and expire old unkept debriefs while at it.
+///
+/// Gated on the AI engine being on and a provider being reachable — the same
+/// conditions as slot scoring, and deliberately independent of
+/// `disable_work_summaries`: that switch governs the note that syncs, and a
+/// debrief never leaves the machine.
+pub fn generate_pending_debriefs(db: &Database) {
+    let mut config_path = crate::env::get_app_home();
+    config_path.push("config.json");
+    let config = crate::config::load_config(config_path).unwrap_or_default();
+
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64;
+
+    // Retention is a property of the stored data, not of the AI being
+    // reachable, so it runs before any gate.
+    match db.prune_expired_debriefs(now, DEBRIEF_RETENTION_DAYS * 86_400) {
+        Ok(n) if n > 0 => println!("[Debrief] Expired {n} old debrief(s)."),
+        Ok(_) => {}
+        Err(err) => eprintln!("[Debrief] Could not expire old debriefs: {err:?}"),
+    }
+
+    if config.engine_mode != "llm" {
+        return;
+    }
+    let Some(provider) = crate::llm::get_llm_provider(&config) else {
+        return;
+    };
+
+    let pending = match db.days_needing_debrief(now, SUMMARY_LOOKBACK_DAYS) {
+        Ok(days) => days,
+        Err(err) => {
+            eprintln!("[Debrief] Could not list days needing a debrief: {err:?}");
+            return;
+        }
+    };
+
+    for (day_start, day_end) in pending {
+        let Some(prep) = prepare_debrief_inputs(db, &config, day_start, day_end) else {
+            continue;
+        };
+        println!("[Debrief] Writing the private debrief for the day starting {day_start}...");
+        let narrative =
+            match provider.write_debrief(&crate::config::debrief_prompt(), &prep.activity_text) {
+                Ok(text) => text,
+                Err(err) => {
+                    // Left unwritten: the next loop retries, same as a note.
+                    eprintln!("[Debrief] The AI could not write a debrief for {day_start}: {err}");
+                    continue;
+                }
+            };
+        let accounting_json = serde_json::to_string(&prep.accounting).unwrap_or_default();
+        if let Err(err) = db.insert_daily_debrief(
+            day_start,
+            day_end,
+            &narrative,
+            &accounting_json,
+            prep.reconciliation,
+            &prep.episodes_json,
+            now,
+        ) {
+            eprintln!("[Debrief] Could not store the debrief for {day_start}: {err:?}");
+        }
+    }
 }
 
 /// Say once per run — not once per 60-second loop — that an install which used to
@@ -695,6 +865,28 @@ fn meeting_creditable_ceiling(total_minutes: u32, demoted_meeting_minutes: u32) 
     ((creditable * 100) / 10).min(100)
 }
 
+/// Unkept debriefs expire after this many days (#113). A debrief is regenerable
+/// from the minute logs while they exist, so expiry deletes convenience, not
+/// evidence — and a candid document should not accumulate indefinitely by mere
+/// inertia.
+pub const DEBRIEF_RETENTION_DAYS: i64 = 30;
+
+/// A day with less presence than this has nothing worth a paragraph.
+const DEBRIEF_MIN_PRESENCE_MINUTES: u32 = 30;
+
+/// The display name of a minute's classification, shared by the slot auditor's
+/// activity lines and the debrief's episode builder.
+fn state_name(c: crate::evaluator::ActivityClassification) -> &'static str {
+    match c {
+        crate::evaluator::ActivityClassification::Active => "Active",
+        crate::evaluator::ActivityClassification::PassiveReview => "PassiveReview",
+        crate::evaluator::ActivityClassification::Meeting => "Meeting",
+        crate::evaluator::ActivityClassification::Idle => "Idle",
+        crate::evaluator::ActivityClassification::Distracted => "Distracted",
+        crate::evaluator::ActivityClassification::Tampered => "Tampered",
+    }
+}
+
 /// Local wall-clock label (HH:MM) for a minute timestamp. The auditor is asked to
 /// cite these in its reasoning, so they must match the clock the user (and anyone
 /// reading the dashboard beside them) actually saw — hence local time, not UTC.
@@ -791,14 +983,7 @@ pub fn aggregate_slot(db: &Database, config: &crate::config::AgentConfig, slot_s
             consecutive_silent_meeting = 0;
         }
 
-        minute_states.push(match classification {
-            crate::evaluator::ActivityClassification::Active => "Active",
-            crate::evaluator::ActivityClassification::PassiveReview => "PassiveReview",
-            crate::evaluator::ActivityClassification::Meeting => "Meeting",
-            crate::evaluator::ActivityClassification::Idle => "Idle",
-            crate::evaluator::ActivityClassification::Distracted => "Distracted",
-            crate::evaluator::ActivityClassification::Tampered => "Tampered",
-        });
+        minute_states.push(state_name(classification));
 
         let is_active = classification == crate::evaluator::ActivityClassification::Active
             || classification == crate::evaluator::ActivityClassification::PassiveReview
@@ -1048,6 +1233,94 @@ mod tests {
     use std::path::PathBuf;
     use std::sync::Arc;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    /// The reconciliation switch decides what the model is ever shown (#113): an
+    /// ordinary day's prompt carries no Distracted episode and says so; a day
+    /// with a material gap carries them and asks for the accounting.
+    #[test]
+    fn debrief_inputs_withhold_offwork_on_quiet_days_and_include_it_on_gap_days() {
+        let db = Arc::new(create_test_db());
+        let mut config = AgentConfig::default();
+        config.distracting_apps = "youtube".to_string();
+        config.productive_apps = "vscode, cursor".to_string();
+
+        // Quiet day: four fully productive slots (40m, above the presence floor).
+        for slot_idx in 0..4i64 {
+            let slot = 600 + slot_idx * 600;
+            for i in 0..10 {
+                db.insert_minute_log(slot + i * 60, 80, 6, 0, 5.0, "Code", "billing.rs", false)
+                    .unwrap();
+            }
+            aggregate_slot(&db, &config, slot);
+        }
+        let (day_start, day_end) = crate::db::local_day_bounds(600);
+        let prep = prepare_debrief_inputs(&db, &config, day_start, day_end)
+            .expect("a 40-minute fully productive day clears the presence floor");
+        assert!(!prep.reconciliation);
+        assert!(
+            prep.activity_text.contains("ordinary day"),
+            "quiet days say so: {}",
+            prep.activity_text
+        );
+        assert!(
+            !prep.activity_text.contains("Distracted"),
+            "no off-work lines on a quiet day: {}",
+            prep.activity_text
+        );
+
+        // Gap day, fresh db: 1 productive slot, then 70 minutes of YouTube —
+        // 10 credited of 80 present, a 70-minute gap, comfortably past both
+        // reconciliation floors.
+        let db2 = Arc::new(create_test_db());
+        for i in 0..10 {
+            db2.insert_minute_log(600 + i * 60, 80, 6, 0, 5.0, "Code", "billing.rs", false)
+                .unwrap();
+        }
+        aggregate_slot(&db2, &config, 600);
+        for slot_idx in 0..7i64 {
+            let slot = 1200 + slot_idx * 600;
+            for i in 0..10 {
+                db2.insert_minute_log(
+                    slot + i * 60,
+                    0,
+                    2,
+                    5,
+                    3.0,
+                    "YouTube",
+                    "definitely leisure",
+                    false,
+                )
+                .unwrap();
+            }
+            aggregate_slot(&db2, &config, slot);
+        }
+        let prep2 = prepare_debrief_inputs(&db2, &config, day_start, day_end)
+            .expect("an 80-minute day clears the presence floor");
+        assert!(
+            prep2.reconciliation,
+            "10 credited of 80 present is a material gap"
+        );
+        assert!(
+            prep2.activity_text.contains("Distracted"),
+            "gap days include the off-work episodes: {}",
+            prep2.activity_text
+        );
+        assert!(
+            prep2
+                .activity_text
+                .contains("account for where that time went"),
+            "{}",
+            prep2.activity_text
+        );
+        let episodes: Vec<crate::debrief::Episode> =
+            serde_json::from_str(&prep2.episodes_json).unwrap();
+        assert!(
+            episodes
+                .iter()
+                .any(|e| e.matched_keyword.as_deref() == Some("youtube")),
+            "the matched keyword is stored for the UI's correction control"
+        );
+    }
 
     /// The auditor is only as concrete as its input (#111): every line must carry
     /// the minute label, all three input counts, cursor travel, and the daemon's

--- a/daemon/src/db.rs
+++ b/daemon/src/db.rs
@@ -504,6 +504,25 @@ impl Database {
             [],
         )?;
 
+        // Private daily debriefs (#113). Deliberately outside the ledger and the
+        // sync path by construction: no hash, no parent link, no signature, no
+        // synced flag, and nothing in `sync.rs` reads this table. A debrief is a
+        // mirror for the worker, not an attestation — it expires (see
+        // `prune_expired_debriefs`) unless the worker keeps it.
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS daily_debriefs (
+                day_start INTEGER PRIMARY KEY,
+                day_end INTEGER NOT NULL,
+                narrative TEXT NOT NULL,
+                accounting TEXT NOT NULL,
+                reconciliation INTEGER NOT NULL,
+                episodes TEXT NOT NULL,
+                generated_at INTEGER NOT NULL,
+                kept INTEGER NOT NULL DEFAULT 0
+            )",
+            [],
+        )?;
+
         // Daily work summaries (ADR 0019), on their own hash chain. They are independent
         // of slot ordering — a summary attests "this text described this period, written
         // at this time" — so they link to each other rather than interleaving with slots.
@@ -1315,27 +1334,80 @@ impl Database {
     /// block in [`crate::untrusted::fence`] before it reaches a model: scrubbing is
     /// what makes the fence hold, it is not the fence.
     pub fn activity_digest(&self, from: i64, to: i64) -> Result<Vec<String>> {
-        let conn = self.conn.lock().unwrap();
-        let mut stmt = conn.prepare(
-            "SELECT m.active_app_name, m.active_window_title, COUNT(*) AS minutes
-             FROM minute_logs m
-             JOIN slot_summaries s
-               ON s.slot_start = m.timestamp - (m.timestamp % 600)
-             WHERE m.timestamp >= ?1 AND m.timestamp < ?2
-               AND s.focus_score >= ?3
-               AND (m.keystroke_count > 0 OR m.mouse_click_count > 0 OR m.scroll_event_count > 0)
-             GROUP BY m.active_app_name, m.active_window_title
-             HAVING minutes >= 2
-             ORDER BY minutes DESC
-             LIMIT 60",
-        )?;
-        let rows = stmt.query_map(params![from, to, BILLABLE_FOCUS_THRESHOLD], |row| {
-            let app = crate::untrusted::scrub(&row.get::<_, String>(0)?);
-            let title = crate::untrusted::scrub(&row.get::<_, String>(1)?);
-            let minutes: i64 = row.get(2)?;
-            Ok(format!("{minutes}m — {app}: {title}"))
-        })?;
-        rows.collect()
+        // Chronological runs, not a ranked tally (#113): the model is asked to
+        // narrate the day, and a word cloud with the chronology deleted cannot
+        // be narrated. Same filters as before — billable slots, input minutes —
+        // only the shape of the digest changed.
+        let minutes: Vec<(i64, String, String)> = {
+            let conn = self.conn.lock().unwrap();
+            let mut stmt = conn.prepare(
+                "SELECT m.timestamp, m.active_app_name, m.active_window_title
+                 FROM minute_logs m
+                 JOIN slot_summaries s
+                   ON s.slot_start = m.timestamp - (m.timestamp % 600)
+                 WHERE m.timestamp >= ?1 AND m.timestamp < ?2
+                   AND s.focus_score >= ?3
+                   AND (m.keystroke_count > 0 OR m.mouse_click_count > 0 OR m.scroll_event_count > 0)
+                 ORDER BY m.timestamp ASC",
+            )?;
+            let rows = stmt.query_map(params![from, to, BILLABLE_FOCUS_THRESHOLD], |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                ))
+            })?;
+            rows.collect::<Result<Vec<_>>>()?
+        };
+
+        // Collapse consecutive minutes of the same app+title into one run. A
+        // single skipped minute does not break a run; a longer hole does.
+        struct Run {
+            start: i64,
+            end: i64,
+            minutes: i64,
+            app: String,
+            title: String,
+        }
+        let mut runs: Vec<Run> = Vec::new();
+        for (ts, app, title) in minutes {
+            match runs.last_mut() {
+                Some(run) if run.app == app && run.title == title && ts - run.end <= 120 => {
+                    run.end = ts + 60;
+                    run.minutes += 1;
+                }
+                _ => runs.push(Run {
+                    start: ts,
+                    end: ts + 60,
+                    minutes: 1,
+                    app,
+                    title,
+                }),
+            }
+        }
+        runs.retain(|r| r.minutes >= 2);
+
+        // The 60-line ceiling keeps the longest runs but renders them in day
+        // order, so the cap trims resolution rather than scrambling the story.
+        if runs.len() > 60 {
+            runs.sort_by_key(|r| std::cmp::Reverse(r.minutes));
+            runs.truncate(60);
+            runs.sort_by_key(|r| r.start);
+        }
+
+        Ok(runs
+            .iter()
+            .map(|r| {
+                format!(
+                    "{}–{} ({}m) — {}: {}",
+                    crate::debrief::hh_mm(r.start),
+                    crate::debrief::hh_mm(r.end),
+                    r.minutes,
+                    crate::untrusted::scrub(&r.app),
+                    crate::untrusted::scrub(&r.title),
+                )
+            })
+            .collect())
     }
 
     /// Every distinct window title recorded in `[from, to)`.
@@ -1414,6 +1486,185 @@ impl Database {
 
     /// Whether a period already has a summary, at any revision. The generator uses this
     /// to stay idempotent across restarts.
+    /// Whether a debrief already exists for the local day starting at `day_start`.
+    pub fn has_daily_debrief(&self, day_start: i64) -> Result<bool> {
+        let conn = self.conn.lock().unwrap();
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM daily_debriefs WHERE day_start = ?1",
+            params![day_start],
+            |row| row.get(0),
+        )?;
+        Ok(count > 0)
+    }
+
+    /// Store a finished debrief. One per day; regenerating a day replaces it.
+    #[allow(clippy::too_many_arguments)]
+    pub fn insert_daily_debrief(
+        &self,
+        day_start: i64,
+        day_end: i64,
+        narrative: &str,
+        accounting_json: &str,
+        reconciliation: bool,
+        episodes_json: &str,
+        generated_at: i64,
+    ) -> Result<()> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "INSERT OR REPLACE INTO daily_debriefs
+             (day_start, day_end, narrative, accounting, reconciliation, episodes, generated_at, kept)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7,
+                     COALESCE((SELECT kept FROM daily_debriefs WHERE day_start = ?1), 0))",
+            params![
+                day_start,
+                day_end,
+                narrative,
+                accounting_json,
+                reconciliation as i32,
+                episodes_json,
+                generated_at
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Debriefs covering `[from, to)`, oldest first, for the dashboard day view.
+    pub fn get_daily_debriefs(&self, from: i64, to: i64) -> Result<Vec<DailyDebriefView>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT day_start, day_end, narrative, accounting, reconciliation, episodes,
+                    generated_at, kept
+             FROM daily_debriefs
+             WHERE day_start >= ?1 AND day_start < ?2
+             ORDER BY day_start ASC",
+        )?;
+        let rows = stmt.query_map(params![from, to], |row| {
+            let accounting_raw: String = row.get(3)?;
+            let episodes_raw: String = row.get(5)?;
+            let recon_int: i32 = row.get(4)?;
+            let kept_int: i32 = row.get(7)?;
+            let accounting: crate::debrief::DayAccounting =
+                serde_json::from_str(&accounting_raw).unwrap_or_default();
+            Ok(DailyDebriefView {
+                day_start: row.get(0)?,
+                day_end: row.get(1)?,
+                narrative: row.get(2)?,
+                accounting_line: crate::debrief::format_accounting_line(&accounting),
+                accounting,
+                reconciliation: recon_int != 0,
+                episodes: serde_json::from_str(&episodes_raw).unwrap_or_default(),
+                generated_at: row.get(6)?,
+                kept: kept_int != 0,
+            })
+        })?;
+        rows.collect()
+    }
+
+    /// Mark a day's debrief as kept (exempt from expiry) or not.
+    pub fn set_debrief_kept(&self, day_start: i64, kept: bool) -> Result<()> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "UPDATE daily_debriefs SET kept = ?2 WHERE day_start = ?1",
+            params![day_start, kept as i32],
+        )?;
+        Ok(())
+    }
+
+    /// Delete unkept debriefs older than the retention window. A debrief is
+    /// regenerable from the minute logs while they exist, so expiry costs
+    /// nothing the worker cannot get back by asking.
+    pub fn prune_expired_debriefs(&self, now_ts: i64, retention_secs: i64) -> Result<usize> {
+        let conn = self.conn.lock().unwrap();
+        let n = conn.execute(
+            "DELETE FROM daily_debriefs WHERE kept = 0 AND generated_at < ?1",
+            params![now_ts - retention_secs],
+        )?;
+        Ok(n)
+    }
+
+    /// Finished local days that have slot activity but no debrief yet — the
+    /// debrief twin of [`Self::days_needing_summary`], checked against its own
+    /// table so notes and debriefs generate independently.
+    pub fn days_needing_debrief(&self, now_ts: i64, lookback_days: i64) -> Result<Vec<(i64, i64)>> {
+        let earliest = now_ts - lookback_days * 86_400;
+        let slot_starts: Vec<i64> = {
+            let conn = self.conn.lock().unwrap();
+            let mut stmt = conn.prepare(
+                "SELECT DISTINCT slot_start FROM slot_summaries
+                 WHERE slot_start >= ?1 ORDER BY slot_start ASC",
+            )?;
+            let rows = stmt.query_map(params![earliest], |row| row.get(0))?;
+            rows.collect::<Result<Vec<i64>>>()?
+        };
+
+        let mut pending: Vec<(i64, i64)> = Vec::new();
+        for slot_start in slot_starts {
+            let (day_start, day_end) = local_day_bounds(slot_start);
+            if day_end > now_ts {
+                continue; // only whole, finished days
+            }
+            if pending.iter().any(|(s, _)| *s == day_start) {
+                continue;
+            }
+            if !self.has_daily_debrief(day_start)? {
+                pending.push((day_start, day_end));
+            }
+        }
+        Ok(pending)
+    }
+
+    /// The day's category minutes summed across its slots — the ledger's own
+    /// arithmetic, reused rather than re-derived, so the debrief's accounting
+    /// line always agrees with what the slots actually credited.
+    pub fn day_category_minutes(
+        &self,
+        from: i64,
+        to: i64,
+    ) -> Result<std::collections::HashMap<String, u32>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT app_categories FROM slot_summaries
+             WHERE slot_start >= ?1 AND slot_start < ?2",
+        )?;
+        let rows = stmt.query_map(params![from, to], |row| row.get::<_, String>(0))?;
+        let mut totals: std::collections::HashMap<String, u32> = std::collections::HashMap::new();
+        for raw in rows.flatten() {
+            if let Ok(map) = serde_json::from_str::<std::collections::HashMap<String, u32>>(&raw) {
+                for (k, v) in map {
+                    *totals.entry(k).or_insert(0) += v;
+                }
+            }
+        }
+        Ok(totals)
+    }
+
+    /// Every raw minute log in `[from, to)`, oldest first — the debrief's
+    /// unfiltered input. Unlike [`Self::activity_digest`] nothing is gated on
+    /// billability here: this feeds a document that never leaves the machine.
+    pub fn minute_logs_in_period(&self, from: i64, to: i64) -> Result<Vec<MinuteLogData>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT timestamp, keystroke_count, mouse_click_count, scroll_event_count, active_app_name, active_window_title, low_entropy, mouse_movement_distance 
+             FROM minute_logs 
+             WHERE timestamp >= ?1 AND timestamp < ?2
+             ORDER BY timestamp ASC",
+        )?;
+        let rows = stmt.query_map(params![from, to], |row| {
+            let low_entropy_int: i32 = row.get(6)?;
+            Ok(MinuteLogData {
+                timestamp: row.get(0)?,
+                keystroke_count: row.get(1)?,
+                mouse_click_count: row.get(2)?,
+                scroll_event_count: row.get(3)?,
+                active_app_name: row.get(4)?,
+                active_window_title: row.get(5)?,
+                low_entropy: low_entropy_int != 0,
+                mouse_movement_distance: row.get(7)?,
+            })
+        })?;
+        rows.collect()
+    }
+
     pub fn has_work_summary(&self, period_start: i64) -> Result<bool> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
@@ -1752,6 +2003,22 @@ pub struct SlotSummaryView {
     pub hash: String,
     pub parent_hash: String,
     pub llm_reasoning: Option<String>,
+}
+
+/// A stored daily debrief as the dashboard renders it (#113). Local-only by
+/// construction — see the table comment in `initialize`.
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct DailyDebriefView {
+    pub day_start: i64,
+    pub day_end: i64,
+    pub narrative: String,
+    pub accounting: crate::debrief::DayAccounting,
+    /// Pre-formatted for display so the UI never re-derives the numbers.
+    pub accounting_line: String,
+    pub reconciliation: bool,
+    pub episodes: Vec<crate::debrief::Episode>,
+    pub generated_at: i64,
+    pub kept: bool,
 }
 
 /// A minute-by-minute activity row within a slot, with its classified `state`
@@ -3144,8 +3411,8 @@ e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855|CONFIGHASH|PARE
         );
         assert!(digest[0].contains("billing.rs"), "got {:?}", digest[0]);
         assert!(
-            digest[0].starts_with("4m"),
-            "minutes are grouped: {:?}",
+            digest[0].contains("(4m)"),
+            "consecutive minutes collapse into one run with its span: {:?}",
             digest[0]
         );
         assert!(
@@ -3209,6 +3476,69 @@ e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855|CONFIGHASH|PARE
         let stored = &db.get_minute_logs_for_slot(0).unwrap()[0].active_window_title;
         assert_eq!(stored.chars().count(), crate::untrusted::MAX_TITLE_CHARS);
         assert!(long_emoji_title.starts_with(stored));
+    }
+
+    /// Debriefs live outside the ledger by construction (#113): their table has
+    /// no signature or chain columns, expiry deletes unkept rows only, and one
+    /// day holds one debrief however often it regenerates.
+    #[test]
+    fn test_debrief_roundtrip_expiry_and_kept() {
+        let db = create_test_db();
+        let acc = serde_json::to_string(&crate::debrief::DayAccounting {
+            presence: 480,
+            credited: 180,
+            meeting: 0,
+            waste: 200,
+            idle: 100,
+            tampered: 0,
+        })
+        .unwrap();
+
+        db.insert_daily_debrief(0, 86_400, "First try.", &acc, true, "[]", 1_000)
+            .unwrap();
+        db.insert_daily_debrief(0, 86_400, "Second try.", &acc, true, "[]", 2_000)
+            .unwrap();
+        let views = db.get_daily_debriefs(0, 86_400).unwrap();
+        assert_eq!(views.len(), 1, "one debrief per day");
+        assert_eq!(views[0].narrative, "Second try.");
+        assert!(views[0].reconciliation);
+        assert_eq!(views[0].accounting.presence, 480);
+        assert!(views[0].accounting_line.contains("8h at the computer"));
+
+        // Unkept debriefs expire; kept ones survive the same sweep.
+        db.insert_daily_debrief(86_400, 172_800, "Old day.", &acc, false, "[]", 3_000)
+            .unwrap();
+        db.set_debrief_kept(0, true).unwrap();
+        let pruned = db
+            .prune_expired_debriefs(10_000 + 30 * 86_400, 30 * 86_400)
+            .unwrap();
+        assert_eq!(pruned, 1, "only the unkept one goes");
+        let left = db.get_daily_debriefs(0, 200_000).unwrap();
+        assert_eq!(left.len(), 1);
+        assert_eq!(left[0].day_start, 0, "the kept debrief survived");
+
+        // Re-generation must not clear the kept flag.
+        db.insert_daily_debrief(0, 86_400, "Third try.", &acc, true, "[]", 4_000)
+            .unwrap();
+        assert!(db.get_daily_debriefs(0, 86_400).unwrap()[0].kept);
+    }
+
+    /// `days_needing_debrief` mirrors the note's day discovery but consults its
+    /// own table, so notes and debriefs generate independently.
+    #[test]
+    fn test_days_needing_debrief_is_independent_of_notes() {
+        let db = create_test_db();
+        db.insert_slot_summary(600, 80, 8, 2, 100, 10, "{}", None, "", None)
+            .unwrap();
+        let (day_start, day_end) = local_day_bounds(600);
+        let now = day_end + 3_600;
+
+        let pending = db.days_needing_debrief(now, 7).unwrap();
+        assert_eq!(pending, vec![(day_start, day_end)]);
+
+        db.insert_daily_debrief(day_start, day_end, "Done.", "{}", false, "[]", now)
+            .unwrap();
+        assert!(db.days_needing_debrief(now, 7).unwrap().is_empty());
     }
 
     /// The note echo check gets the whole day, not the billable part the model saw:

--- a/daemon/src/debrief.rs
+++ b/daemon/src/debrief.rs
@@ -1,0 +1,588 @@
+//! The private daily debrief (#113).
+//!
+//! A debrief is the worker-facing counterpart of the client-facing work note: one
+//! candid paragraph about the day plus a deterministic account of where the time
+//! went. It exists for the person who did the work and for nobody else, which is
+//! why everything about it is built to stay on the machine: it is stored in its
+//! own table with no hash, no signature and no sync flag (`db::insert_daily_debrief`),
+//! the sync module never reads that table, and rows expire after
+//! [`crate::daemon::DEBRIEF_RETENTION_DAYS`] unless the worker keeps them.
+//!
+//! **Explanation scales with the gap.** The debrief explains variance, not virtue.
+//! Every day gets one neutral accounting line (numbers, no names). Only when
+//! credited time falls well short of presence ([`needs_reconciliation`]) do the
+//! distraction and idle episodes reach the model at all — on an ordinary day they
+//! are withheld from the prompt entirely, so the narrative cannot moralize about a
+//! day that needs no explaining, and the junk-site titles those episodes tend to
+//! carry stay out of the request.
+//!
+//! This module is pure bookkeeping: segmentation, accounting, and prompt lines.
+//! Generation (the AI call, storage, retention) lives in
+//! `daemon::generate_pending_debriefs`.
+
+use crate::db::MinuteLogData;
+use std::collections::HashMap;
+
+/// Reconciliation triggers when credited time is under this share of presence…
+pub const RECON_MAX_CREDITED_PCT: u32 = 70;
+/// …and the absolute gap also exceeds this many minutes. The pair means short
+/// days are not punished (3h credited of 3.5h present stays quiet) and long good
+/// days are not lectured (10h of 12h stays quiet).
+pub const RECON_MIN_GAP_MINUTES: u32 = 60;
+
+/// Episodes shorter than this are folded into a neighbour: a one-minute detour
+/// is texture, not an episode. Deliberate cost: a stretch of rapid app-flipping
+/// collapses into the episode it interrupts rather than rendering as confetti.
+pub const SHORT_EPISODE_MIN_MINUTES: u32 = 2;
+
+/// A hole between logged minutes at least this long becomes an explicit "Away"
+/// episode. Locked or asleep minutes are never logged, so the gaps are real and
+/// naming them is what lets the narrative describe the shape of the day
+/// ("long break around lunch") instead of leaving unexplained holes.
+pub const AWAY_GAP_MIN_SECS: i64 = 120;
+
+/// Ceiling on episode lines handed to the model. On a pathologically fragmented
+/// day the longest episodes are kept and re-sorted chronologically, so the cap
+/// trims resolution, never the day's shape.
+pub const DIGEST_MAX_LINES: usize = 80;
+
+/// One contiguous stretch of the day: same app, same state, no gap.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct Episode {
+    pub start: i64,
+    /// Exclusive end (last minute's timestamp + 60).
+    pub end: i64,
+    pub minutes: u32,
+    pub app: String,
+    /// The title seen for the most minutes of the episode.
+    pub title: String,
+    /// "Active" | "PassiveReview" | "Meeting" | "Idle" | "Distracted" |
+    /// "Tampered" | "Away".
+    pub state: String,
+    pub keys: u32,
+    pub clicks: u32,
+    pub scrolls: u32,
+    /// For a Distracted episode: the configured `distracting_apps` keyword that
+    /// matched. Stored so the dashboard's "not a distraction" control can name
+    /// exactly what it would remove.
+    pub matched_keyword: Option<String>,
+}
+
+/// The day's arithmetic, summed from the slots' own signed category counts —
+/// the same numbers the ledger carries, not a re-derivation that could drift.
+#[derive(Debug, Clone, Copy, PartialEq, Default, serde::Serialize, serde::Deserialize)]
+pub struct DayAccounting {
+    pub presence: u32,
+    pub credited: u32,
+    pub meeting: u32,
+    pub waste: u32,
+    pub idle: u32,
+    pub tampered: u32,
+}
+
+impl DayAccounting {
+    /// Build from a summed `app_categories` map ("Productive"/"Meeting"/"Waste"/
+    /// "Inactive"/"Tampered" → minutes).
+    pub fn from_category_minutes(categories: &HashMap<String, u32>) -> Self {
+        let get = |k: &str| categories.get(k).copied().unwrap_or(0);
+        let productive = get("Productive");
+        let meeting = get("Meeting");
+        let waste = get("Waste");
+        let idle = get("Inactive");
+        let tampered = get("Tampered");
+        DayAccounting {
+            presence: productive + meeting + waste + idle + tampered,
+            credited: productive + meeting,
+            meeting,
+            waste,
+            idle,
+            tampered,
+        }
+    }
+}
+
+/// Whether the day's gap is material enough to explain: credited under
+/// [`RECON_MAX_CREDITED_PCT`] of presence AND more than [`RECON_MIN_GAP_MINUTES`]
+/// unaccounted for. Both constants live in code, not config — a threshold the
+/// worker could tune would quietly become a verdict they set for themselves.
+pub fn needs_reconciliation(acc: &DayAccounting) -> bool {
+    acc.presence > 0
+        && acc.credited * 100 < acc.presence * RECON_MAX_CREDITED_PCT
+        && acc.presence - acc.credited > RECON_MIN_GAP_MINUTES
+}
+
+/// "7h50m" / "45m" / "0m".
+pub fn format_duration_minutes(minutes: u32) -> String {
+    if minutes >= 60 {
+        let m = minutes % 60;
+        if m == 0 {
+            format!("{}h", minutes / 60)
+        } else {
+            format!("{}h{:02}m", minutes / 60, m)
+        }
+    } else {
+        format!("{}m", minutes)
+    }
+}
+
+/// The always-shown accounting line: numbers, no names, no judgment.
+/// "9h12m at the computer · 7h50m credited (1h40m in meetings) · 1h22m other"
+pub fn format_accounting_line(acc: &DayAccounting) -> String {
+    let mut line = format!(
+        "{} at the computer · {} credited",
+        format_duration_minutes(acc.presence),
+        format_duration_minutes(acc.credited),
+    );
+    if acc.meeting > 0 {
+        line.push_str(&format!(
+            " ({} in meetings)",
+            format_duration_minutes(acc.meeting)
+        ));
+    }
+    let other = acc.presence.saturating_sub(acc.credited);
+    if other > 0 {
+        line.push_str(&format!(" · {} other", format_duration_minutes(other)));
+    }
+    line
+}
+
+/// Local wall-clock HH:MM for a timestamp, falling back to the raw number when
+/// the local time is unrepresentable (a DST edge).
+pub fn hh_mm(ts: i64) -> String {
+    use chrono::TimeZone;
+    chrono::Local
+        .timestamp_opt(ts, 0)
+        .single()
+        .map(|dt| dt.format("%H:%M").to_string())
+        .unwrap_or_else(|| ts.to_string())
+}
+
+/// Which configured distraction keyword a minute matched, if any. Mirrors the
+/// evaluator's matching (case-insensitive substring over app and title) so the
+/// stored keyword is the one that actually caused the classification.
+fn matched_distraction_keyword(app: &str, title: &str, distracting_apps: &str) -> Option<String> {
+    let app_lower = app.to_lowercase();
+    let title_lower = title.to_lowercase();
+    distracting_apps
+        .split(',')
+        .map(|s| s.trim().to_lowercase())
+        .filter(|s| !s.is_empty())
+        .find(|kw| app_lower.contains(kw) || title_lower.contains(kw))
+}
+
+/// Segment a day of minute logs into [`Episode`]s.
+///
+/// `states[i]` is the evaluator's verdict for `logs[i]` — computed by the caller
+/// with the same rules the slots were scored under, minus billing-only
+/// adjustments (the silent-meeting demotion exists to bound credit, not to
+/// describe a day). Boundaries fall on an app change, a state change, or a gap
+/// of [`AWAY_GAP_MIN_SECS`]+ (which becomes an explicit Away episode). Episodes
+/// shorter than [`SHORT_EPISODE_MIN_MINUTES`] are folded into their neighbour.
+pub fn build_episodes(
+    logs: &[MinuteLogData],
+    states: &[&'static str],
+    distracting_apps: &str,
+) -> Vec<Episode> {
+    assert_eq!(logs.len(), states.len(), "one state per minute");
+
+    struct Open {
+        start: i64,
+        end: i64,
+        app: String,
+        state: &'static str,
+        keys: u32,
+        clicks: u32,
+        scrolls: u32,
+        title_minutes: HashMap<String, u32>,
+        matched_keyword: Option<String>,
+    }
+
+    fn close(open: Open) -> Episode {
+        let title = open
+            .title_minutes
+            .iter()
+            .max_by_key(|(_, m)| **m)
+            .map(|(t, _)| t.clone())
+            .unwrap_or_default();
+        Episode {
+            start: open.start,
+            end: open.end,
+            minutes: ((open.end - open.start) / 60).max(0) as u32,
+            app: open.app,
+            title,
+            state: open.state.to_string(),
+            keys: open.keys,
+            clicks: open.clicks,
+            scrolls: open.scrolls,
+            matched_keyword: open.matched_keyword,
+        }
+    }
+
+    let mut episodes: Vec<Episode> = Vec::new();
+    let mut open: Option<Open> = None;
+
+    for (log, state) in logs.iter().zip(states.iter()) {
+        if let Some(cur) = &open {
+            let gap = log.timestamp - cur.end;
+            if gap >= AWAY_GAP_MIN_SECS {
+                let (away_start, away_end) = (cur.end, log.timestamp);
+                episodes.push(close(open.take().unwrap()));
+                episodes.push(Episode {
+                    start: away_start,
+                    end: away_end,
+                    minutes: ((away_end - away_start) / 60).max(0) as u32,
+                    app: String::new(),
+                    title: String::new(),
+                    state: "Away".to_string(),
+                    keys: 0,
+                    clicks: 0,
+                    scrolls: 0,
+                    matched_keyword: None,
+                });
+            } else if cur.app != log.active_app_name || cur.state != *state {
+                episodes.push(close(open.take().unwrap()));
+            }
+        }
+
+        match open.as_mut() {
+            Some(cur) => {
+                cur.end = log.timestamp + 60;
+                cur.keys += log.keystroke_count;
+                cur.clicks += log.mouse_click_count;
+                cur.scrolls += log.scroll_event_count;
+                *cur.title_minutes
+                    .entry(log.active_window_title.clone())
+                    .or_insert(0) += 1;
+            }
+            None => {
+                let matched = if *state == "Distracted" {
+                    matched_distraction_keyword(
+                        &log.active_app_name,
+                        &log.active_window_title,
+                        distracting_apps,
+                    )
+                } else {
+                    None
+                };
+                let mut title_minutes = HashMap::new();
+                title_minutes.insert(log.active_window_title.clone(), 1);
+                open = Some(Open {
+                    start: log.timestamp,
+                    end: log.timestamp + 60,
+                    app: log.active_app_name.clone(),
+                    state,
+                    keys: log.keystroke_count,
+                    clicks: log.mouse_click_count,
+                    scrolls: log.scroll_event_count,
+                    title_minutes,
+                    matched_keyword: matched,
+                });
+            }
+        }
+    }
+    if let Some(cur) = open {
+        episodes.push(close(cur));
+    }
+
+    // Fold sub-threshold episodes into the previous mergeable neighbour; a short
+    // head episode folds forward into the one after it instead. Away episodes
+    // neither absorb nor get absorbed — a real hole in the day stays a hole.
+    let mut merged: Vec<Episode> = Vec::new();
+    for ep in episodes {
+        let short = ep.minutes < SHORT_EPISODE_MIN_MINUTES && ep.state != "Away";
+        match merged.last_mut() {
+            Some(prev) if short && prev.state != "Away" => {
+                prev.end = ep.end;
+                prev.minutes += ep.minutes;
+                prev.keys += ep.keys;
+                prev.clicks += ep.clicks;
+                prev.scrolls += ep.scrolls;
+            }
+            _ => merged.push(ep),
+        }
+    }
+    if merged.len() >= 2
+        && merged[0].minutes < SHORT_EPISODE_MIN_MINUTES
+        && merged[0].state != "Away"
+        && merged[1].state != "Away"
+    {
+        let head = merged.remove(0);
+        let next = &mut merged[0];
+        next.start = head.start;
+        next.minutes += head.minutes;
+        next.keys += head.keys;
+        next.clicks += head.clicks;
+        next.scrolls += head.scrolls;
+    }
+    merged
+}
+
+/// The episode lines handed to the model, chronological, scrubbed, capped.
+///
+/// `include_offwork` is the reconciliation switch: `false` (a quiet day) keeps
+/// only Active / PassiveReview / Meeting / Away episodes, so distraction and
+/// idle detail — and the titles it carries — never reaches the model at all;
+/// `true` (a day whose gap needs explaining) includes everything. Away lines
+/// survive both modes: they carry no title and they are the shape of the day.
+pub fn digest_lines(episodes: &[Episode], include_offwork: bool) -> Vec<String> {
+    let mut kept: Vec<&Episode> = episodes
+        .iter()
+        .filter(|ep| {
+            include_offwork
+                || matches!(
+                    ep.state.as_str(),
+                    "Active" | "PassiveReview" | "Meeting" | "Away"
+                )
+        })
+        .collect();
+
+    if kept.len() > DIGEST_MAX_LINES {
+        kept.sort_by_key(|ep| std::cmp::Reverse(ep.minutes));
+        kept.truncate(DIGEST_MAX_LINES);
+        kept.sort_by_key(|ep| ep.start);
+    }
+
+    kept.iter()
+        .map(|ep| {
+            if ep.state == "Away" {
+                format!(
+                    "{}–{} ({}) — Away from the computer (no minutes recorded)",
+                    hh_mm(ep.start),
+                    hh_mm(ep.end),
+                    format_duration_minutes(ep.minutes),
+                )
+            } else {
+                format!(
+                    "{}–{} ({}) — App: '{}', Title: '{}', State: {}, Keys: {}, Clicks: {}, Scrolls: {}",
+                    hh_mm(ep.start),
+                    hh_mm(ep.end),
+                    format_duration_minutes(ep.minutes),
+                    crate::untrusted::scrub(&ep.app),
+                    crate::untrusted::scrub(&ep.title),
+                    ep.state,
+                    ep.keys,
+                    ep.clicks,
+                    ep.scrolls,
+                )
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn minute(ts: i64, app: &str, title: &str, keys: u32) -> MinuteLogData {
+        MinuteLogData {
+            timestamp: ts,
+            keystroke_count: keys,
+            mouse_click_count: 0,
+            scroll_event_count: 0,
+            active_app_name: app.to_string(),
+            active_window_title: title.to_string(),
+            low_entropy: false,
+            mouse_movement_distance: 0.0,
+        }
+    }
+
+    #[test]
+    fn episodes_split_on_app_and_state_and_absorb_one_minute_blips() {
+        // 4m coding, a 1m chat blip (absorbed), 3m more coding, then 3m YouTube.
+        let logs = vec![
+            minute(0, "Code", "billing.rs", 50),
+            minute(60, "Code", "billing.rs", 40),
+            minute(120, "Code", "sync.rs", 45),
+            minute(180, "Code", "billing.rs", 30),
+            minute(240, "Slack", "#general", 5),
+            minute(300, "Code", "billing.rs", 60),
+            minute(360, "Code", "billing.rs", 55),
+            minute(420, "Code", "billing.rs", 20),
+            minute(480, "YouTube", "cat videos", 0),
+            minute(540, "YouTube", "cat videos", 3),
+            minute(600, "YouTube", "cat videos", 0),
+        ];
+        let states: Vec<&'static str> = vec![
+            "Active",
+            "Active",
+            "Active",
+            "Active",
+            "Active",
+            "Active",
+            "Active",
+            "Active",
+            "Distracted",
+            "Distracted",
+            "Distracted",
+        ];
+        let eps = build_episodes(&logs, &states, "youtube");
+        assert_eq!(eps.len(), 3, "code, code-again, youtube: {eps:#?}");
+        assert_eq!(eps[0].app, "Code");
+        assert_eq!(eps[0].minutes, 5, "the 1m Slack blip is folded in");
+        assert_eq!(eps[0].title, "billing.rs", "dominant title wins");
+        assert_eq!(eps[1].app, "Code");
+        assert_eq!(eps[2].state, "Distracted");
+        assert_eq!(eps[2].matched_keyword.as_deref(), Some("youtube"));
+        assert_eq!(eps[2].minutes, 3);
+    }
+
+    #[test]
+    fn a_gap_becomes_an_away_episode_and_short_head_folds_forward() {
+        let logs = vec![
+            minute(0, "Code", "a.rs", 10),
+            // 58 minutes of nothing recorded.
+            minute(3540, "Code", "a.rs", 10),
+            minute(3600, "Code", "a.rs", 10),
+        ];
+        let states: Vec<&'static str> = vec!["Active", "Active", "Active"];
+        let eps = build_episodes(&logs, &states, "");
+        assert_eq!(eps.len(), 3, "{eps:#?}");
+        assert_eq!(eps[1].state, "Away");
+        assert_eq!(eps[1].minutes, 58);
+        // The 1-minute head could not merge backwards (nothing there) and must
+        // not merge across the Away hole.
+        assert_eq!(eps[0].minutes, 1);
+        assert_eq!(eps[2].minutes, 2);
+    }
+
+    #[test]
+    fn reconciliation_trigger_matches_the_worked_examples() {
+        let acc = |presence, credited, meeting| DayAccounting {
+            presence,
+            credited,
+            meeting,
+            waste: 0,
+            idle: presence - credited,
+            tampered: 0,
+        };
+        // 10h credited of 12h present: quiet (83% yield).
+        assert!(!needs_reconciliation(&acc(720, 600, 0)));
+        // 3h credited of 8h present: explain (37%, 5h gap).
+        assert!(needs_reconciliation(&acc(480, 180, 0)));
+        // Short good day, 3h of 3.5h: quiet (86%).
+        assert!(!needs_reconciliation(&acc(210, 180, 0)));
+        // 11h of 12h with 5h meetings: meetings are credited, quiet.
+        assert!(!needs_reconciliation(&acc(720, 660, 300)));
+        // Low ratio but the absolute gap stays under the hour floor
+        // (45m credited of 100m present, 55m gap): quiet.
+        assert!(!needs_reconciliation(&acc(100, 45, 0)));
+        // Empty day: quiet.
+        assert!(!needs_reconciliation(&DayAccounting::default()));
+    }
+
+    #[test]
+    fn accounting_line_reads_as_numbers_without_judgment() {
+        let acc = DayAccounting {
+            presence: 552,
+            credited: 470,
+            meeting: 100,
+            waste: 42,
+            idle: 40,
+            tampered: 0,
+        };
+        assert_eq!(
+            format_accounting_line(&acc),
+            "9h12m at the computer · 7h50m credited (1h40m in meetings) · 1h22m other"
+        );
+        let clean = DayAccounting {
+            presence: 60,
+            credited: 60,
+            meeting: 0,
+            waste: 0,
+            idle: 0,
+            tampered: 0,
+        };
+        assert_eq!(
+            format_accounting_line(&clean),
+            "1h at the computer · 1h credited"
+        );
+    }
+
+    #[test]
+    fn quiet_days_withhold_offwork_episodes_from_the_model() {
+        let eps = vec![
+            Episode {
+                start: 0,
+                end: 600,
+                minutes: 10,
+                app: "Code".into(),
+                title: "a.rs".into(),
+                state: "Active".into(),
+                keys: 100,
+                clicks: 5,
+                scrolls: 0,
+                matched_keyword: None,
+            },
+            Episode {
+                start: 600,
+                end: 1800,
+                minutes: 20,
+                app: "YouTube".into(),
+                title: "definitely not work".into(),
+                state: "Distracted".into(),
+                keys: 0,
+                clicks: 9,
+                scrolls: 40,
+                matched_keyword: Some("youtube".into()),
+            },
+            Episode {
+                start: 1800,
+                end: 2400,
+                minutes: 10,
+                app: String::new(),
+                title: String::new(),
+                state: "Away".into(),
+                keys: 0,
+                clicks: 0,
+                scrolls: 0,
+                matched_keyword: None,
+            },
+        ];
+        let quiet = digest_lines(&eps, false);
+        assert_eq!(quiet.len(), 2, "work + away survive: {quiet:#?}");
+        assert!(
+            quiet.iter().all(|l| !l.contains("definitely not work")),
+            "a distraction title must not reach a quiet day's prompt"
+        );
+        let recon = digest_lines(&eps, true);
+        assert_eq!(recon.len(), 3);
+        assert!(recon[1].contains("State: Distracted"));
+    }
+
+    #[test]
+    fn digest_cap_keeps_longest_but_renders_chronologically() {
+        let mut eps = Vec::new();
+        for i in 0..(DIGEST_MAX_LINES as i64 + 20) {
+            eps.push(Episode {
+                start: i * 600,
+                end: i * 600 + 600,
+                minutes: if i % 2 == 0 { 10 } else { 2 },
+                app: format!("App{i}"),
+                title: "t".into(),
+                state: "Active".into(),
+                keys: 1,
+                clicks: 0,
+                scrolls: 0,
+                matched_keyword: None,
+            });
+        }
+        let lines = digest_lines(&eps, true);
+        assert_eq!(lines.len(), DIGEST_MAX_LINES);
+        // Chronology is checked via the unique app index in each line, not the
+        // HH:MM label — wall-clock order isn't lexical across midnight.
+        let indices: Vec<usize> = lines
+            .iter()
+            .map(|l| {
+                l.split("App: 'App")
+                    .nth(1)
+                    .and_then(|rest| rest.split('\'').next())
+                    .and_then(|n| n.parse().ok())
+                    .expect("every kept line carries its app index")
+            })
+            .collect();
+        assert!(
+            indices.windows(2).all(|w| w[0] < w[1]),
+            "chronological after the cap: {indices:?}"
+        );
+    }
+}

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -2,6 +2,7 @@ pub mod config;
 pub mod daemon;
 pub mod dashboard;
 pub mod db;
+pub mod debrief;
 pub mod entropy;
 pub mod env;
 pub mod evaluator;

--- a/daemon/src/llm.rs
+++ b/daemon/src/llm.rs
@@ -93,6 +93,11 @@ pub trait LlmProvider {
     /// Write the daily work note (ADR 0019). Same provider and key as scoring, but the
     /// reply is prose rather than JSON, because this text is what a client reads.
     fn write_note(&self, system_prompt: &str, activity_text: &str) -> Result<String, String>;
+
+    /// Write the private daily debrief (#113): the same prose call as a note, but
+    /// contained by [`sanitize_debrief`] — a paragraph is the expected shape, so
+    /// the ceiling is [`MAX_DEBRIEF_CHARS`] rather than a note's two sentences.
+    fn write_debrief(&self, system_prompt: &str, activity_text: &str) -> Result<String, String>;
 }
 
 /// Guard rail on whatever the model returns. The note publishes without a review step,
@@ -106,6 +111,23 @@ pub trait LlmProvider {
 /// cannot see is whether the *words* came from a window title — that needs the day's
 /// titles, so it is checked in `daemon::generate_pending_summaries` before signing.
 pub fn sanitize_note(raw: &str) -> Result<String, String> {
+    sanitize_prose(raw, 600, "one or two sentences")
+}
+
+/// Ceiling on a debrief narrative, in characters. A paragraph of four to eight
+/// sentences fits comfortably; like the note's 600 this rejects a malfunction,
+/// not a style.
+pub const MAX_DEBRIEF_CHARS: usize = 2400;
+
+/// Guard rail for the debrief paragraph — [`sanitize_note`]'s rules at
+/// paragraph size. The debrief never publishes, but it is still model output
+/// rendered in the dashboard, so the same malfunctions are refused: emptiness,
+/// echoed fence markers, essays.
+pub fn sanitize_debrief(raw: &str) -> Result<String, String> {
+    sanitize_prose(raw, MAX_DEBRIEF_CHARS, "one paragraph")
+}
+
+fn sanitize_prose(raw: &str, max_chars: usize, expected: &str) -> Result<String, String> {
     // Flatten control characters and whitespace runs: the note is signed, stored, and
     // rendered next to an invoice, and a model that wrapped its sentence over three
     // lines has not written a different note.
@@ -123,10 +145,11 @@ pub fn sanitize_note(raw: &str) -> Result<String, String> {
     if crate::untrusted::contains_fence_marker(&text) {
         return Err("model echoed the untrusted-data markers back into the note".into());
     }
-    if text.chars().count() > 600 {
+    if text.chars().count() > max_chars {
         return Err(format!(
-            "model returned {} characters; expected one or two sentences",
-            text.chars().count()
+            "model returned {} characters; expected {}",
+            text.chars().count(),
+            expected
         ));
     }
     Ok(text)
@@ -227,6 +250,18 @@ impl LlmProvider for OpenAiProvider {
     }
 
     fn write_note(&self, system_prompt: &str, activity_text: &str) -> Result<String, String> {
+        sanitize_note(&self.prose_reply(system_prompt, activity_text)?)
+    }
+
+    fn write_debrief(&self, system_prompt: &str, activity_text: &str) -> Result<String, String> {
+        sanitize_debrief(&self.prose_reply(system_prompt, activity_text)?)
+    }
+}
+
+impl OpenAiProvider {
+    /// One prose completion, uncontained: every caller wraps this in the
+    /// sanitizer matching what it asked for.
+    fn prose_reply(&self, system_prompt: &str, activity_text: &str) -> Result<String, String> {
         let payload = serde_json::json!({
             "model": self.model,
             "messages": [
@@ -246,7 +281,7 @@ impl LlmProvider for OpenAiProvider {
         let json = res.json::<Value>().map_err(|e| e.to_string())?;
 
         match json["choices"][0]["message"]["content"].as_str() {
-            Some(content) => sanitize_note(content),
+            Some(content) => Ok(content.to_string()),
             None => Err("Failed to parse OpenAI note response".into()),
         }
     }
@@ -323,6 +358,18 @@ impl LlmProvider for AnthropicProvider {
     }
 
     fn write_note(&self, system_prompt: &str, activity_text: &str) -> Result<String, String> {
+        sanitize_note(&self.prose_reply(system_prompt, activity_text)?)
+    }
+
+    fn write_debrief(&self, system_prompt: &str, activity_text: &str) -> Result<String, String> {
+        sanitize_debrief(&self.prose_reply(system_prompt, activity_text)?)
+    }
+}
+
+impl AnthropicProvider {
+    /// One prose completion, uncontained: every caller wraps this in the
+    /// sanitizer matching what it asked for.
+    fn prose_reply(&self, system_prompt: &str, activity_text: &str) -> Result<String, String> {
         let payload = serde_json::json!({
             "model": self.model,
             "max_tokens": 4096,
@@ -355,7 +402,7 @@ impl LlmProvider for AnthropicProvider {
             .or_else(|| json["content"][0]["text"].as_str());
 
         match text {
-            Some(content) => sanitize_note(content),
+            Some(content) => Ok(content.to_string()),
             None => Err("Failed to parse Anthropic note response".into()),
         }
     }
@@ -416,6 +463,18 @@ impl LlmProvider for GeminiProvider {
     }
 
     fn write_note(&self, system_prompt: &str, activity_text: &str) -> Result<String, String> {
+        sanitize_note(&self.prose_reply(system_prompt, activity_text)?)
+    }
+
+    fn write_debrief(&self, system_prompt: &str, activity_text: &str) -> Result<String, String> {
+        sanitize_debrief(&self.prose_reply(system_prompt, activity_text)?)
+    }
+}
+
+impl GeminiProvider {
+    /// One prose completion, uncontained: every caller wraps this in the
+    /// sanitizer matching what it asked for.
+    fn prose_reply(&self, system_prompt: &str, activity_text: &str) -> Result<String, String> {
         let payload = serde_json::json!({
             "systemInstruction": { "parts": [{ "text": system_prompt }] },
             "contents": [{
@@ -439,7 +498,7 @@ impl LlmProvider for GeminiProvider {
         let json = res.json::<Value>().map_err(|e| e.to_string())?;
 
         match json["candidates"][0]["content"]["parts"][0]["text"].as_str() {
-            Some(content) => sanitize_note(content),
+            Some(content) => Ok(content.to_string()),
             None => Err("Failed to parse Gemini note response".into()),
         }
     }

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -488,6 +488,62 @@ async fn dashboard_work_notes(
         .map_err(|e| format!("Database error: {}", e))
 }
 
+/// The private daily debriefs covering `[from, to)` (#113). Local-only data:
+/// this command is the only reader, and nothing in the sync path can reach the
+/// table it comes from.
+#[tauri::command]
+async fn dashboard_debriefs(
+    db: tauri::State<'_, Arc<daemon::db::Database>>,
+    from: i64,
+    to: i64,
+) -> Result<Vec<daemon::db::DailyDebriefView>, String> {
+    let db_clone = db.inner().clone();
+    tokio::task::spawn_blocking(move || db_clone.get_daily_debriefs(from, to))
+        .await
+        .map_err(|e| format!("Task join error: {}", e))?
+        .map_err(|e| format!("Database error: {}", e))
+}
+
+/// Exempt one day's debrief from the retention sweep, or hand it back.
+#[tauri::command]
+async fn debrief_set_kept(
+    db: tauri::State<'_, Arc<daemon::db::Database>>,
+    day_start: i64,
+    kept: bool,
+) -> Result<(), String> {
+    let db_clone = db.inner().clone();
+    tokio::task::spawn_blocking(move || db_clone.set_debrief_kept(day_start, kept))
+        .await
+        .map_err(|e| format!("Task join error: {}", e))?
+        .map_err(|e| format!("Database error: {}", e))
+}
+
+/// Remove one keyword from `distracting_apps` — the debrief's "not a
+/// distraction" control. Affects how future minutes are classified; scored
+/// slots keep the verdicts they were signed under.
+#[tauri::command]
+async fn remove_distracting_keyword(keyword: String) -> Result<(), String> {
+    tokio::task::spawn_blocking(move || {
+        let mut config_path = daemon::env::get_app_home();
+        config_path.push("config.json");
+        let mut config = daemon::config::load_config(config_path.clone())?;
+        let needle = keyword.trim().to_lowercase();
+        if needle.is_empty() {
+            return Err("no keyword given".to_string());
+        }
+        let kept: Vec<&str> = config
+            .distracting_apps
+            .split(',')
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty() && s.to_lowercase() != needle)
+            .collect();
+        config.distracting_apps = kept.join(", ");
+        daemon::config::save_config(config_path, &config)
+    })
+    .await
+    .map_err(|err| format!("keyword removal panicked: {err}"))?
+}
+
 /// Whether note generation is live right now: the user's own AI is configured and
 /// notes are not opted out. Drives the dashboard's empty state, so the invitation
 /// only appears to people who would actually gain something by acting on it.
@@ -867,6 +923,9 @@ pub fn run() {
             dashboard_pending_slots,
             dashboard_slot_details,
             dashboard_work_notes,
+            dashboard_debriefs,
+            debrief_set_kept,
+            remove_distracting_keyword,
             work_notes_enabled,
             export_dashboard_csv,
             get_agent_config,

--- a/desktop/src/dashboard.css
+++ b/desktop/src/dashboard.css
@@ -895,6 +895,121 @@
             color: var(--text-muted);
         }
 
+        /* Private daily debrief (#113): candid, so visually calm on purpose —
+           neutral surfaces, no alarm colors on the card itself, the same weight
+           on a reconciled day as on a quiet one. */
+        .debrief-card {
+            background: rgba(255, 255, 255, 0.03);
+            border: 1px solid var(--border-card);
+            border-radius: 12px;
+            padding: 1.2rem 1.4rem;
+            margin-bottom: 2rem;
+        }
+
+        .debrief-head {
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+            gap: 1rem;
+            flex-wrap: wrap;
+        }
+
+        .debrief-badge {
+            font-size: 0.7rem;
+            color: var(--text-muted);
+            border: 1px solid var(--border-card);
+            border-radius: 999px;
+            padding: 0.15rem 0.6rem;
+            white-space: nowrap;
+        }
+
+        .debrief-accounting {
+            font-size: 0.85rem;
+            font-weight: 600;
+            color: var(--text-muted);
+            margin: 0 0 0.7rem 0;
+            letter-spacing: 0.2px;
+        }
+
+        .debrief-actions {
+            display: flex;
+            gap: 0.6rem;
+            margin-top: 0.9rem;
+            flex-wrap: wrap;
+        }
+
+        .debrief-action-btn,
+        .debrief-fix-btn {
+            background: rgba(255, 255, 255, 0.05);
+            border: 1px solid var(--border-card);
+            border-radius: 6px;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+            padding: 0.3rem 0.7rem;
+            cursor: pointer;
+        }
+
+        .debrief-action-btn:hover,
+        .debrief-fix-btn:hover {
+            color: var(--text-primary, #e5e7eb);
+            border-color: rgba(255, 255, 255, 0.3);
+        }
+
+        .debrief-episodes {
+            margin-top: 0.9rem;
+            border-top: 1px solid var(--border-card);
+            padding-top: 0.6rem;
+        }
+
+        .debrief-episode-row {
+            display: flex;
+            align-items: baseline;
+            gap: 0.8rem;
+            padding: 0.35rem 0;
+            font-size: 0.82rem;
+            border-bottom: 1px dashed rgba(255, 255, 255, 0.06);
+        }
+
+        .debrief-episode-span {
+            flex: 0 0 6.5rem;
+            color: var(--text-muted);
+            font-variant-numeric: tabular-nums;
+        }
+
+        .debrief-episode-mins {
+            flex: 0 0 3rem;
+            text-align: right;
+            color: var(--text-muted);
+            font-variant-numeric: tabular-nums;
+        }
+
+        .debrief-episode-app {
+            flex: 1 1 auto;
+            color: var(--text-primary, #e5e7eb);
+            min-width: 0;
+            overflow-wrap: anywhere;
+        }
+
+        .debrief-episode-title {
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+            font-size: 0.78rem;
+        }
+
+        .debrief-state-chip {
+            flex: 0 0 auto;
+            font-size: 0.68rem;
+            border-radius: 999px;
+            padding: 0.1rem 0.55rem;
+            border: 1px solid var(--border-card);
+            color: var(--text-muted);
+        }
+
+        .debrief-state-active { color: var(--accent-green); border-color: rgba(16, 185, 129, 0.4); }
+        .debrief-state-passivereview,
+        .debrief-state-meeting { color: #7dd3fc; border-color: rgba(125, 211, 252, 0.35); }
+        .debrief-state-distracted { color: var(--accent-yellow); border-color: rgba(245, 158, 11, 0.4); }
+
         .work-note-row {
             display: flex;
             gap: 1rem;

--- a/desktop/src/dashboard.js
+++ b/desktop/src/dashboard.js
@@ -41,6 +41,11 @@ function goHome() {
         // does, this can go and workNotesEnabled alone will be right again.
         let aiEngineOn = false;
 
+        // Private daily debriefs (#113), keyed by YYYY-MM-DD. Local-only data:
+        // absent is a normal state (AI off, day too small, or expired), and an
+        // absent debrief renders as nothing at all — never as a nag.
+        let debriefs = {};
+
         function dateKeyOf(unixSeconds) {
             const d = new Date(unixSeconds * 1000);
             const y = d.getFullYear();
@@ -65,6 +70,104 @@ function goHome() {
             } catch (err) {
                 console.error('Error fetching work notes', err);
             }
+        }
+
+        async function fetchDebriefs() {
+            try {
+                const rows = await invoke('dashboard_debriefs', { from: 0, to: 4102444800 });
+                debriefs = {};
+                (rows || []).forEach(d => {
+                    debriefs[dateKeyOf(d.day_start)] = d;
+                });
+            } catch (err) {
+                console.error('Error fetching debriefs', err);
+            }
+        }
+
+        function hhmm(unixSeconds) {
+            return new Date(unixSeconds * 1000).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false });
+        }
+
+        const DEBRIEF_STATE_LABELS = {
+            Active: 'Working',
+            PassiveReview: 'Reading',
+            Meeting: 'Meeting',
+            Idle: 'Idle',
+            Distracted: 'Distraction',
+            Tampered: 'Flagged',
+            Away: 'Away',
+        };
+
+        /// One row of the debrief's episode list. Titles render into a hidden
+        /// span so nothing sensitive is on screen until explicitly asked for —
+        /// including in reconciliation mode.
+        function renderEpisodeRow(ep) {
+            const label = DEBRIEF_STATE_LABELS[ep.state] || ep.state;
+            const stateClass = `debrief-state-${ep.state.toLowerCase()}`;
+            const span = `${hhmm(ep.start)}–${hhmm(ep.end)}`;
+            const what = ep.state === 'Away'
+                ? '<em>Away from the computer</em>'
+                : escapeHtml(ep.app || '(unknown app)');
+            const title = ep.state !== 'Away' && ep.title
+                ? `<span class="debrief-episode-title" style="display:none;">${escapeHtml(ep.title)}</span>`
+                : '';
+            let fix = '';
+            if (ep.state === 'Distracted' && ep.matched_keyword) {
+                fix = `<button type="button" class="debrief-fix-btn"
+                          data-remove-distraction="${escapeHtml(ep.matched_keyword)}">
+                          Not a distraction</button>`;
+            }
+            return `
+                <div class="debrief-episode-row">
+                    <span class="debrief-episode-span">${span}</span>
+                    <span class="debrief-episode-mins">${ep.minutes}m</span>
+                    <span class="debrief-episode-app">${what}${title}</span>
+                    <span class="debrief-state-chip ${stateClass}">${label}</span>
+                    ${fix}
+                </div>
+            `;
+        }
+
+        /// The private debrief card under the day's note (#113). Returns '' when
+        /// no debrief exists — quiet is a designed state here.
+        function renderDebrief(dateKey) {
+            const d = debriefs[dateKey];
+            if (!d) return '';
+            const recon = !!d.reconciliation;
+            const episodes = d.episodes || [];
+            const expanded = recon;
+            const explainer = recon
+                ? `<span class="work-note-meta">Shown in detail because credited time was well below time at the computer.</span>`
+                : '';
+            const keepLabel = d.kept
+                ? 'Kept · click to let it expire'
+                : 'Keep this day';
+            return `
+                <div class="debrief-card">
+                    <div class="debrief-head">
+                        <h4 class="work-note-label">Your day, privately</h4>
+                        <span class="debrief-badge">Stays on this device · ${d.kept ? 'kept' : 'expires after 30 days'}</span>
+                    </div>
+                    <p class="debrief-accounting">${escapeHtml(d.accounting_line)}</p>
+                    <p class="work-note-text">${escapeHtml(d.narrative)}</p>
+                    ${explainer}
+                    <div class="debrief-actions">
+                        <button type="button" class="debrief-action-btn" data-debrief-toggle="${d.day_start}">
+                            ${expanded ? '▾' : '▸'} Episodes (${episodes.length})
+                        </button>
+                        <button type="button" class="debrief-action-btn" data-debrief-keep="${d.day_start}" data-kept="${d.kept ? '1' : '0'}">
+                            ${keepLabel}
+                        </button>
+                    </div>
+                    <div class="debrief-episodes" id="debrief-episodes-${d.day_start}" style="display:${expanded ? 'block' : 'none'};">
+                        ${episodes.map(renderEpisodeRow).join('')}
+                        ${episodes.some(e => e.state !== 'Away' && e.title) ? `
+                        <button type="button" class="debrief-action-btn" data-debrief-titles="${d.day_start}">
+                            Show window titles
+                        </button>` : ''}
+                    </div>
+                </div>
+            `;
         }
 
         /// The note card shown above a day's timeline. Returns '' when there is
@@ -115,6 +218,7 @@ function goHome() {
                 const slots = await invoke('dashboard_slots');
                 const pendingSlots = await invoke('dashboard_pending_slots');
                 await fetchWorkNotes();
+                await fetchDebriefs();
 
                 globalSlots = slots || [];
 
@@ -734,6 +838,8 @@ function goHome() {
 
                 ${renderWorkNote(currentDateKey)}
 
+                ${renderDebrief(currentDateKey)}
+
                 <div style="margin-bottom: 2rem; background: rgba(0,0,0,0.15); border: 1px solid var(--border-card); border-radius: 12px; padding: 1.2rem;">
                     <h4 style="font-size: 0.8rem; text-transform: uppercase; color: var(--text-muted); letter-spacing: 0.8px; margin-bottom: 0.6rem;">24-Hour Focus Heatmap</h4>
                     <div class="heatmap-bar">
@@ -1138,6 +1244,63 @@ function goHome() {
         document.addEventListener('click', (event) => {
             const target = event.target;
             if (!(target instanceof Element)) return;
+
+            const debriefToggle = target.closest('[data-debrief-toggle]');
+            if (debriefToggle) {
+                const list = document.getElementById(`debrief-episodes-${debriefToggle.getAttribute('data-debrief-toggle')}`);
+                if (list) {
+                    const nowOpen = list.style.display === 'none';
+                    list.style.display = nowOpen ? 'block' : 'none';
+                    debriefToggle.textContent = `${nowOpen ? '▾' : '▸'} ${debriefToggle.textContent.slice(2)}`;
+                }
+                return;
+            }
+
+            const titlesBtn = target.closest('[data-debrief-titles]');
+            if (titlesBtn) {
+                const list = document.getElementById(`debrief-episodes-${titlesBtn.getAttribute('data-debrief-titles')}`);
+                if (list) {
+                    const hidden = list.querySelector('.debrief-episode-title')?.style.display === 'none';
+                    list.querySelectorAll('.debrief-episode-title').forEach(el => {
+                        el.style.display = hidden ? 'inline' : 'none';
+                    });
+                    titlesBtn.textContent = hidden ? 'Hide window titles' : 'Show window titles';
+                }
+                return;
+            }
+
+            const keepBtn = target.closest('[data-debrief-keep]');
+            if (keepBtn) {
+                const dayStart = Number(keepBtn.getAttribute('data-debrief-keep'));
+                const kept = keepBtn.getAttribute('data-kept') === '1';
+                invoke('debrief_set_kept', { dayStart, kept: !kept })
+                    .then(() => fetchDebriefs())
+                    .then(() => renderCurrentView())
+                    .catch(err => console.error('Could not update the debrief', err));
+                return;
+            }
+
+            // Two clicks on purpose: the first arms, the second removes. A rule
+            // change deserves a beat of confirmation, without a dialog.
+            const fixBtn = target.closest('[data-remove-distraction]');
+            if (fixBtn) {
+                const keyword = fixBtn.getAttribute('data-remove-distraction');
+                if (fixBtn.getAttribute('data-armed') !== '1') {
+                    fixBtn.setAttribute('data-armed', '1');
+                    fixBtn.textContent = `Remove '${keyword}' from distractions?`;
+                    return;
+                }
+                invoke('remove_distracting_keyword', { keyword })
+                    .then(() => {
+                        fixBtn.textContent = 'Removed · applies to future days';
+                        fixBtn.disabled = true;
+                    })
+                    .catch(err => {
+                        fixBtn.textContent = 'Could not remove — see Settings';
+                        console.error('Could not remove distraction keyword', err);
+                    });
+                return;
+            }
 
             const scroller = target.closest('[data-scroll-to]');
             if (scroller) {


### PR DESCRIPTION
Closes #113.

## Summary

**A second daily summary, for the worker only.** When the AI engine is on, the daemon writes one private debrief per finished day: a paragraph from the user's own AI over an unfiltered, chronological episode digest (new `debrief` module — segmentation at app/state change-points, away-gap detection, sub-2-minute folding, dominant titles), above a deterministic accounting line summed from the slots' own signed category counts — so the numbers always agree with the ledger.

**Explanation scales with the gap.** Every day gets the accounting line ("9h12m at the computer · 7h50m credited (1h40m in meetings) · 1h22m other"). The Distracted and Idle episodes are included in the prompt — and the episode list rendered expanded — only when credited time is under 70% of presence with more than an hour unaccounted for. On ordinary days those episodes are withheld from the request entirely, not merely hidden, so titles from distracting apps stay out of it; the constants live in code, not settings. The card states the rule in one line when it fires. The prompt is instructed to describe, never prescribe, and to judge Distracted episodes by their titles rather than their labels.

**A mirror, not an attestation.** The `daily_debriefs` table has no hash, no signature, no sync flag; nothing in `sync.rs` reads it; rows expire after 30 days unless kept (one click). The debrief pipeline shares nothing with the note pipeline.

**Dashboard.** The card renders under the work note: accounting line, paragraph, episodes behind a click (expanded on reconciliation days), titles behind a second explicit click in every mode, per-episode state chips, and a two-click "not a distraction" control that removes the matched keyword from `distracting_apps` — labeled as applying to future days, since scored slots keep the verdicts they were signed under.

**Client note digest, same change:** `activity_digest` now emits chronological runs (`09:10–09:52 (42m) — App: Title`) instead of a ranked tally, with the same billable-only and input-only filters, so the note can narrate the day.

**AUDIT.md, same PR:** §2 gains the third BYOK call (with the reconciliation-only condition under which distracting-app titles reach the provider), §1a documents the local-only table and its expiry, and verdict row 5 names all three call sites.

## Tests

Episode segmentation (splits, folding, away gaps, dominant titles), reconciliation trigger against the worked examples, quiet-vs-gap prompt assembly (off-work withheld vs included, matched keyword stored), debrief roundtrip/expiry/kept, digest chronology. 143 daemon + 15 desktop, green; clippy `-D warnings` clean both workspaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)