### PR TITLE
docs: re-point provenance issue refs at the current tracker

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -77,7 +77,7 @@ and record the *timing gap* between presses (for bot detection), never *what* wa
   (counts only).
 - [daemon.rs:263-276](daemon/src/daemon.rs#L263) — mouse *movement* stores `(x, y, timestamp)` for
   entropy analysis. This is cursor coordinates, not content.
-- A **second, listen-only** tap in [provenance.rs](daemon/src/provenance.rs) (issue #87) — on macOS a
+- A **second, listen-only** tap in [provenance.rs](daemon/src/provenance.rs) — on macOS a
   `CGEventTap` reading only `kCGEventSourceStateID`, on Windows low-level hooks reading only the
   injected-event flag — classifies each event as real-hardware vs. software-injected and counts them.
   It never reads the key value either, and passes every event through unchanged.

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -25,10 +25,11 @@ base64 = "0.23.0"
 active-win-pos-rs = "0.11.0"
 keyring = { version = "3", features = ["apple-native", "windows-native"] }
 
-# Input-provenance (issue #87/#101). Platform-specific. core-graphics and
-# core-foundation are version-locked: the tap's run-loop source (a core-graphics
-# CFMachPort) and the CFRunLoop it is added to must share one core-foundation
-# version. core-graphics 0.25 depends on core-foundation 0.10, so both move together.
+# Input-provenance: the macOS event tap and the Windows low-level hooks.
+# Platform-specific. core-graphics and core-foundation are version-locked: the
+# tap's run-loop source (a core-graphics CFMachPort) and the CFRunLoop it is
+# added to must share one core-foundation version. core-graphics 0.25 depends on
+# core-foundation 0.10, so both move together.
 [target.'cfg(target_os = "macos")'.dependencies]
 core-graphics = "0.25"
 core-foundation = "0.10"

--- a/daemon/src/config.rs
+++ b/daemon/src/config.rs
@@ -207,10 +207,11 @@ pub struct AgentConfig {
     pub disable_work_summaries: bool,
     #[serde(default)]
     pub dashboard_port: Option<u16>,
-    /// Enforce synthetic-input detection (#87): mark a minute tampered when its
-    /// input was entirely software-injected. Default off — detection is observe-
-    /// only until on-device red-team calibration (#96), since a bad field read or
-    /// a legit auto-typer could otherwise flag a real user.
+    /// Enforce synthetic-input detection: mark a minute tampered when its input
+    /// was entirely software-injected. Default off — detection is observe-only
+    /// until on-device red-team calibration (the fixture corpus and trace-capture
+    /// tooling that gate needs are tracked in #119), since a bad field read or a
+    /// legit auto-typer could otherwise flag a real user.
     #[serde(default)]
     pub enforce_synthetic_detection: bool,
 }

--- a/daemon/src/daemon.rs
+++ b/daemon/src/daemon.rs
@@ -385,7 +385,7 @@ pub fn start_daemon_loop(db: Arc<Database>, state: Arc<TelemetryState>) {
 
         let classification = evaluator.evaluate_minute(&ctx);
 
-        // Input provenance (#87): surface synthetic (software-injected) input.
+        // Input provenance: surface synthetic (software-injected) input.
         // Detection is observe-only unless enforcement is enabled; the rule only
         // fires when the minute had input but NONE of it was genuine hardware.
         let (synthetic_events, genuine_events) = crate::provenance::take_counts();

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -78,7 +78,7 @@ async fn main() {
     // Start the global event listener thread in the background
     start_input_listener(state.clone());
 
-    // Start the input-provenance monitor (#87): flags software-injected input.
+    // Start the input-provenance monitor: flags software-injected input.
     daemon::provenance::start_provenance_monitor();
 
     // Start the main loop (this blocks and runs indefinitely)

--- a/daemon/src/provenance.rs
+++ b/daemon/src/provenance.rs
@@ -1,4 +1,4 @@
-//! Input provenance — event-source discrimination (issues #87 macOS, #101 Windows).
+//! Input provenance — event-source discrimination (macOS tap, Windows hooks).
 //!
 //! On **macOS**, real hardware input reports `kCGEventSourceStateHIDSystemState`,
 //! while software-injected events (`CGEventPost` — jiggler apps, simple macros)
@@ -19,7 +19,8 @@
 //!   2. Legitimate tools (text expanders, password-manager auto-type) also post
 //!      synthetic events. The enforcement rule that avoids punishing them —
 //!      "the minute had input but *zero* genuine hardware events" — still needs
-//!      on-device red-team calibration (#96) before it is trusted.
+//!      on-device red-team calibration before it is trusted — the fixture
+//!      corpus and trace-capture tooling that gate needs are tracked in #119.
 //!
 //! **Honest limits.** A hardware HID emulator (Teensy/QMK) posts genuine HID
 //! events, and a sophisticated injector can spoof the source state — both evade.
@@ -131,7 +132,7 @@ pub fn start_provenance_monitor() {
     });
 }
 
-// --- Windows: low-level hooks read the explicit injected flag (#101) ---
+// --- Windows: low-level hooks read the explicit injected flag ---
 //
 // `WH_KEYBOARD_LL` / `WH_MOUSE_LL` deliver `KBDLLHOOKSTRUCT` / `MSLLHOOKSTRUCT`
 // whose `flags` carry `LLKHF_INJECTED` / `LLMHF_INJECTED` — a *direct* "this


### PR DESCRIPTION
## Summary

The repository was recreated on 2026-07-13 and the tracker was renumbered with it. Nine comments in tracked, published files still cited the *old* tracker's numbers for the input-provenance / anti-cheat work, which straddled the recreation. All nine resolved to unrelated issues, so an outside reader following one landed on the wrong page:

| Cited | Comment is about | Resolves today to |
|---|---|---|
| `#87` | input provenance, synthetic-input enforcement | `docs: AUDIT.md verification recipes…` (CLOSED) |
| `#96` | on-device red-team calibration gate | `fix(daemon): work notes call the AI even when the engine is set to static` (CLOSED) |
| `#101` | Windows injected-event hooks | `fix(daemon): tighten file permissions…` (MERGED PR) |

Stale numbers are replaced with prose descriptions — the convention ADR 0002's public edition already uses for exactly this reason. The one exception is the red-team calibration gate, which is live and actionable, so it now points at #119 (restoring the fixture corpus and trace-capture tooling that gate depends on).

Closes #122

## Changes

- `AUDIT.md:80` — drop "(issue #87)" from the listen-only tap bullet.
- `daemon/Cargo.toml:28` — "Input-provenance (issue #87/#101)" → names the macOS tap and Windows hooks in prose; comment reflowed.
- `daemon/src/provenance.rs:1` — module doc "(issues #87 macOS, #101 Windows)" → "(macOS tap, Windows hooks)".
- `daemon/src/provenance.rs:22` — red-team calibration now cites #119.
- `daemon/src/provenance.rs:134` — drop "(#101)" from the Windows section banner.
- `daemon/src/config.rs:210-212` — `enforce_synthetic_detection` doc: drop #87, re-point calibration at #119.
- `daemon/src/daemon.rs:388` and `daemon/src/main.rs:81` — drop "(#87)".

Comments and one AUDIT.md line only — no behaviour change.

## Scope

Deliberately **not** a repo-wide sweep. Every neighbouring reference was checked individually against the current tracker and left alone where it still resolves: `#19` (reseal), `#40` (loopback dashboard), `#83`, `#93` (rdev pin *and* the fresh-clone hook guard — both are in that issue's body), `#95`, `#109`, `#111`, `#113`, and the non-provenance `#96` sites in `daemon.rs` / `desktop/`, which correctly cite the current work-note engine gate.

## Testing

- `cd daemon && cargo fmt -- --check`
- `cd daemon && cargo clippy -- -D warnings`
- `cd daemon && cargo test`
- `git ls-files | xargs grep -nE '#(87|96|101)'` — no provenance/anti-cheat hits remain.
