### PR TITLE
docs: tell a stranger how to install this

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,20 @@ Everything is stored locally under `~/.tenby10/`. If you enroll a device, what s
 
 ---
 
+## 📦 Install
+
+```bash
+brew install --cask pivotalpoint-io/tap/tenby10
+```
+
+Or take the `.dmg` straight from [the latest release](https://github.com/pivotalpoint-io/tenby10/releases/latest). Apple silicon, macOS Big Sur or later, signed and notarized.
+
+Windows installers ship with every release too, but they are **not code-signed yet**, so SmartScreen shows an unknown-publisher warning. That is it doing its job on an unsigned installer rather than a sign of anything wrong: verify the download through its [build provenance](#verifying-a-release-download) or build it yourself.
+
+Uninstalling with `brew uninstall --cask tenby10` leaves your ledger under `~/.tenby10` alone, because it is your record and not ours. `--zap` deletes it.
+
+---
+
 ## 🚀 Key Features
 
 *   ⏱️ **Passive, Zero-Friction Tracking**: The background daemon automatically logs active application and window states. Includes a convenient Pause/Resume toggle switch in the system tray and settings UI to control when tracking is active.


### PR DESCRIPTION
## Summary

Adds an Install section above the feature list.

Closes #128. Part of #124, which also covers the tap repository and the repository metadata.

## Why

The README's only `install` mentions were `npm install` for building from source and the provenance snippet. Someone who wanted the app had to infer that Releases existed and then pick the right one of four assets. This is the page a developer lands on from a link or a search, and it did not answer the first question they have.

## What it says

- `brew install --cask pivotalpoint-io/tap/tenby10`
- the direct `.dmg`, with the Apple-silicon and macOS floor stated
- the Windows caveat in the same words used everywhere else: installers ship, they are not signed yet, SmartScreen warns, verify via build provenance or build it yourself
- what an uninstall does to `~/.tenby10`, because the ledger is the user's record and removing it silently would contradict the product

## Note on merge order

The brew line works once `pivotalpoint-io/homebrew-tap` is published. The cask is written and verified against the v0.6.0 dmg (app name, bundle id, arch). If this merges first, that one line is briefly ahead of the tap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)