### PR TITLE
fix(daemon): credit browser-hosted meetings that drop their platform marker

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -254,26 +254,45 @@ held for text metadata, not pixels. The settings page reports whether titles are
 
 All classification is isolated in one pure module so it can be read and unit-tested without the
 capture loop (ADR 0002). A minute is sorted into exactly one state by a fixed priority order in
-[evaluator.rs:114-167](daemon/src/evaluator.rs#L114):
+`evaluate_minute` / `evaluate_stored_minute` in [evaluator.rs](daemon/src/evaluator.rs):
 
 1. **Anti-cheat first** — mouse jiggler or keyboard macro → `Tampered`
-   ([evaluator.rs:115-121](daemon/src/evaluator.rs#L115)).
+   (`is_mouse_jiggler` / `is_keyboard_macro` in [evaluator.rs](daemon/src/evaluator.rs)).
 2. **Distraction** — active app/title matches your `distracting_apps` list → `Distracted`
-   ([evaluator.rs:123-137](daemon/src/evaluator.rs#L123)).
+   (the `distracting_apps` check in [evaluator.rs](daemon/src/evaluator.rs)).
 3. **Active** — any keystroke, click, or scroll → `Active`
-   ([evaluator.rs:139-144](daemon/src/evaluator.rs#L139)).
+   (the input check in [evaluator.rs](daemon/src/evaluator.rs)).
 4. **Meeting** — no input but the active window is a genuine meeting → `Meeting`
-   (`is_meeting_context` in [evaluator.rs](daemon/src/evaluator.rs)). Matching is hardened (#97): a
-   **native meeting app** by application name, a **whole-word** title keyword (so "Meeting notes" is
-   not a meeting), or a Google Meet **URL/code** in the title — not a loose substring. To stop a
-   spoofed/idle "meeting" window from billing a slot on zero interaction, only up to
-   `MEETING_NO_INPUT_STREAK_CAP` **consecutive**
-   no-input meeting minutes count as active — the streak resets on any real input, so an interactive
-   meeting is fully credited but a fully silent slot stays below the billable gate (see
-   `aggregate_slot` in [daemon.rs](daemon/src/daemon.rs)). The bound also holds in LLM mode: demoted
-   minutes are removed from the ceiling the LLM score may claim (`meeting_creditable_ceiling`).
+   (`meeting_context` in [evaluator.rs](daemon/src/evaluator.rs)). Matching is hardened (#97) and
+   carries a **confidence** (#126):
+   - **Strong** — a **native meeting app** by application name, a platform's own **title shell**
+     (`Meet - …`, `… | Microsoft Teams`, `… - Zoom`, Webex, Slack huddles), or a Google Meet
+     **URL/code** in the title. None of these follow from renaming a window.
+   - **Weak** — a **whole-word** title keyword and nothing else, so "Meeting notes" is not a meeting
+     and `myzoomrecording.mp4` is not a meeting, but a tab a user renames to `zoom` still matches at
+     this tier.
+
+   A browser-hosted call is also **carried across minutes** (`MinuteScanner`): Zoom's web client
+   titles its join page `Join from Zoom Workplace app - Zoom` and then retitles the tab to the
+   meeting topic alone, so after the first minute nothing in the window identifies a meeting. The
+   join page is what licenses the next title to be adopted; an unrelated window, an app switch, or a
+   gap in the record (locked or asleep) ends the session, and it is bounded at
+   `MEETING_SESSION_MAX_MINUTES`.
+
+   To stop a spoofed/idle "meeting" window from billing a slot on zero interaction, only a bounded
+   number of **consecutive** no-input meeting minutes count as active — `MEETING_NO_INPUT_STREAK_CAP`
+   on weak evidence, which keeps a fully silent weak-tier slot below the billable gate, and
+   `MEETING_NO_INPUT_STREAK_CAP_STRONG` on strong evidence, where the spoof the bound exists to stop
+   is not available. The streak resets on any real input (see `aggregate_slot` in
+   [daemon.rs](daemon/src/daemon.rs)). The bound also holds in LLM mode: demoted minutes are removed
+   from the ceiling the LLM score may claim (`meeting_creditable_ceiling`).
+
+   None of this proves a human was present in the call. It establishes that a meeting window was
+   frontmost, which is what the signals available without capturing audio or pixels can show.
 5. **Passive review** — no input but a `productive_apps` app *and* you were recently active →
-   `PassiveReview` ([evaluator.rs:151-163](daemon/src/evaluator.rs#L151)).
+   `PassiveReview` ([evaluator.rs](daemon/src/evaluator.rs)). "Recently" is
+   `RECENT_ACTIVITY_WINDOW_MINUTES`, deliberately short: crediting a longer pause is contextual idle
+   forgiveness (ADR 0011), which grants it only when work genuinely resumes.
 6. **Idle** otherwise.
 
 The lists (`distracting_apps`, `productive_apps`, `meeting_apps`) are **user-configurable** and live
@@ -299,9 +318,10 @@ and bias toward never flagging a real person:
   ([daemon.rs:727-783](daemon/src/daemon.rs#L727), ADR 0011).
 
 **The rules are locked by tests** — read these to see the intended behavior as executable spec:
-- [evaluator.rs:223-459](daemon/src/evaluator.rs#L223) — active / passive / idle / distraction / jiggler.
+- the `tests` module in [evaluator.rs](daemon/src/evaluator.rs) — active / passive / idle /
+  distraction / jiggler, meeting confidence tiers, and browser-hosted meeting continuity.
 - [entropy.rs:204-418](daemon/src/entropy.rs#L204) — human vs macro keyboard, human vs jiggler mouse.
-- [daemon.rs:946-1677](daemon/src/daemon.rs#L946) — full-slot aggregation, partial-slot ADR-0006,
+- the `tests` module in [daemon.rs](daemon/src/daemon.rs) — full-slot aggregation, partial-slot ADR-0006,
   idle-forgiveness approved/rejected, and the v2 config-hash binding.
 
 Run them with `cd daemon && cargo test`.

--- a/daemon/src/daemon.rs
+++ b/daemon/src/daemon.rs
@@ -301,7 +301,7 @@ pub fn start_daemon_loop(db: Arc<Database>, state: Arc<TelemetryState>) {
     println!("tenby10 Telemetry Daemon started.");
 
     let evaluator = crate::evaluator::ActivityEvaluator::new();
-    let mut was_recently_active = false;
+    let mut scanner = crate::evaluator::MinuteScanner::new();
 
     // One-time cleanup for machines upgrading from a build that still captured
     // screens (ADR 0018).
@@ -377,13 +377,20 @@ pub fn start_daemon_loop(db: Arc<Database>, state: Arc<TelemetryState>) {
             active_title: &active_title,
             mouse_positions: &mouse_pos,
             key_intervals: &key_intervals,
-            was_recently_active,
+            was_recently_active: scanner.was_recently_active(),
             distracting_apps: &config.distracting_apps,
             productive_apps: &config.productive_apps,
             meeting_apps: &config.meeting_apps,
         };
 
-        let classification = evaluator.evaluate_minute(&ctx);
+        // Advances the recent-input window and any in-progress meeting, so the
+        // console line matches what the aggregator will later score (#126).
+        let (classification, _) = scanner.observe(
+            &active_app,
+            &active_title,
+            &config.meeting_apps,
+            evaluator.evaluate_minute(&ctx),
+        );
 
         // Input provenance (#87): surface synthetic (software-injected) input.
         // Detection is observe-only unless enforcement is enabled; the rule only
@@ -404,9 +411,6 @@ pub fn start_daemon_loop(db: Arc<Database>, state: Arc<TelemetryState>) {
         }
 
         // (Removed categorized_app call since it's unused in the live log loop)
-
-        // Update recently active flag for passive focus calculations
-        was_recently_active = classification == crate::evaluator::ActivityClassification::Active;
 
         println!(
             "[{}] App: '{}' | Keys: {} | Clicks: {} | State: {:?}",
@@ -498,7 +502,7 @@ fn classify_day_minutes(
     config: &crate::config::AgentConfig,
 ) -> Vec<&'static str> {
     let evaluator = crate::evaluator::ActivityEvaluator::new();
-    let mut was_recently_active = false;
+    let mut scanner = crate::evaluator::MinuteScanner::new();
     logs.iter()
         .map(|log| {
             let ctx = crate::evaluator::StoredEvaluationContext {
@@ -508,13 +512,17 @@ fn classify_day_minutes(
                 active_app: &log.active_app_name,
                 active_title: &log.active_window_title,
                 low_entropy: log.low_entropy,
-                was_recently_active,
+                was_recently_active: scanner.was_recently_active(),
                 distracting_apps: &config.distracting_apps,
                 productive_apps: &config.productive_apps,
                 meeting_apps: &config.meeting_apps,
             };
-            let c = evaluator.evaluate_stored_minute(&ctx);
-            was_recently_active = c == crate::evaluator::ActivityClassification::Active;
+            let (c, _) = scanner.observe(
+                &log.active_app_name,
+                &log.active_window_title,
+                &config.meeting_apps,
+                evaluator.evaluate_stored_minute(&ctx),
+            );
             state_name(c)
         })
         .collect()
@@ -852,7 +860,27 @@ pub fn aggregate_pending_slots(db: &Database) {
 /// minutes count as active; the streak resets on any real input, so a genuinely
 /// interactive meeting stays fully credited. Kept below the ADR-0012 billable
 /// gate (40% = 4 minutes) so a fully silent meeting slot cannot bill on its own.
+///
+/// This bound applies to `MeetingConfidence::Weak` evidence — a `meeting_apps`
+/// keyword in a window title, which any rename produces.
 const MEETING_NO_INPUT_STREAK_CAP: u32 = 3;
+
+/// The same bound for `MeetingConfidence::Strong` evidence (#126): a native
+/// meeting client frontmost, a platform's own title shell, or an observed join
+/// transition. None of those follow from renaming a window, so the spoof surface
+/// the weak cap exists to absorb is not present and a silent call may hold a full
+/// slot (ADR 0007). It is still a bound, not an exemption: a stale tab left on a
+/// finished call stops earning at the slot boundary rather than accumulating.
+const MEETING_NO_INPUT_STREAK_CAP_STRONG: u32 = 10;
+
+/// The no-input streak a `Meeting` minute is allowed, by how well the window
+/// identifies the meeting.
+pub fn meeting_streak_cap(confidence: Option<crate::evaluator::MeetingConfidence>) -> u32 {
+    match confidence {
+        Some(crate::evaluator::MeetingConfidence::Strong) => MEETING_NO_INPUT_STREAK_CAP_STRONG,
+        _ => MEETING_NO_INPUT_STREAK_CAP,
+    }
+}
 
 /// Upper bound (percent, fixed 10-minute denominator per ADR 0006) that the LLM
 /// score may claim once meeting-spoof inflation is removed: minutes demoted for
@@ -916,6 +944,74 @@ fn format_activity_line(log: &crate::db::MinuteLogData, state: &str) -> String {
     )
 }
 
+/// Longest spacing between consecutive minute logs still treated as continuous.
+/// Aggregation runs on a 60-second cycle and drifts by a second or two, so this
+/// is generous enough to never split an unbroken run and short enough that a
+/// lock, sleep or paused-tracking gap always breaks one.
+const MINUTE_CONTINUITY_TOLERANCE_SECS: i64 = 180;
+
+/// Minutes of history replayed before a slot is scored (#126). Bounded by
+/// `MEETING_SESSION_MAX_MINUTES`: no meeting session can still be held from
+/// further back, so nothing older can change a verdict in this slot.
+pub const SCANNER_WARMUP_MINUTES: i64 = 240;
+
+/// A [`crate::evaluator::MinuteScanner`] primed with the minutes immediately
+/// before `slot_start`, so a slot is scored from the state the classifier was
+/// actually in rather than from cold.
+///
+/// Slots are scored one at a time, and a meeting rarely starts on a slot
+/// boundary: without this, a call that began at 21:59 loses its session at 22:00
+/// and every ten minutes after that. Verdicts from the warm-up are discarded —
+/// only the carried state matters.
+pub fn warmed_scanner(
+    db: &Database,
+    config: &crate::config::AgentConfig,
+    slot_start: i64,
+    first_scored_minute: i64,
+) -> crate::evaluator::MinuteScanner {
+    let mut scanner = crate::evaluator::MinuteScanner::new();
+    let history = db
+        .get_minute_logs_between(slot_start - SCANNER_WARMUP_MINUTES * 60, slot_start)
+        .unwrap_or_default();
+    let evaluator = crate::evaluator::ActivityEvaluator::new();
+    let mut previous = None;
+    for log in &history {
+        // Telemetry stops while the machine is locked or asleep, so a gap in the
+        // record is a gap in what we know. Whatever was frontmost before it is
+        // not evidence about what is frontmost after, and in particular must not
+        // carry a meeting across it.
+        if previous.is_some_and(|prev| log.timestamp - prev > MINUTE_CONTINUITY_TOLERANCE_SECS) {
+            scanner = crate::evaluator::MinuteScanner::new();
+        }
+        previous = Some(log.timestamp);
+        let evaluated_history =
+            evaluator.evaluate_stored_minute(&crate::evaluator::StoredEvaluationContext {
+                keystroke_count: log.keystroke_count,
+                mouse_click_count: log.mouse_click_count,
+                scroll_event_count: log.scroll_event_count,
+                active_app: &log.active_app_name,
+                active_title: &log.active_window_title,
+                low_entropy: log.low_entropy,
+                was_recently_active: scanner.was_recently_active(),
+                distracting_apps: &config.distracting_apps,
+                productive_apps: &config.productive_apps,
+                meeting_apps: &config.meeting_apps,
+            });
+        scanner.observe(
+            &log.active_app_name,
+            &log.active_window_title,
+            &config.meeting_apps,
+            evaluated_history,
+        );
+    }
+    // The same rule across the join: history that stops well before the minute
+    // we are about to score tells us nothing about it.
+    if previous.is_some_and(|prev| first_scored_minute - prev > MINUTE_CONTINUITY_TOLERANCE_SECS) {
+        scanner = crate::evaluator::MinuteScanner::new();
+    }
+    scanner
+}
+
 pub fn aggregate_slot(db: &Database, config: &crate::config::AgentConfig, slot_start: i64) {
     let logs = match db.get_minute_logs_for_slot(slot_start) {
         Ok(logs) => logs,
@@ -942,7 +1038,7 @@ pub fn aggregate_slot(db: &Database, config: &crate::config::AgentConfig, slot_s
     let mut slot_clicks = 0;
     let mut slot_app_categories = HashMap::<String, u32>::new();
 
-    let mut was_recently_active = false;
+    let mut scanner = warmed_scanner(db, config, slot_start, logs[0].timestamp);
     let mut consecutive_silent_meeting = 0u32;
     let mut demoted_meeting_minutes = 0u32;
     // The final per-minute verdicts (after the silent-meeting demotion), in log
@@ -960,22 +1056,31 @@ pub fn aggregate_slot(db: &Database, config: &crate::config::AgentConfig, slot_s
             active_app: &log.active_app_name,
             active_title: &log.active_window_title,
             low_entropy: log.low_entropy,
-            was_recently_active,
+            was_recently_active: scanner.was_recently_active(),
             distracting_apps: &config.distracting_apps,
             productive_apps: &config.productive_apps,
             meeting_apps: &config.meeting_apps,
         };
 
-        let mut classification = evaluator.evaluate_stored_minute(&ctx);
+        // The scanner carries what a single minute cannot see: the recent-input
+        // window, and an in-progress meeting whose window stopped identifying
+        // itself (#126). It may upgrade `Idle` to `Meeting`.
+        let (mut classification, meeting_confidence) = scanner.observe(
+            &log.active_app_name,
+            &log.active_window_title,
+            &config.meeting_apps,
+            evaluator.evaluate_stored_minute(&ctx),
+        );
 
         // ADR 0002 addendum: bound consecutive no-input Meeting minutes. A
         // `Meeting` classification only occurs with no input (any input
         // classifies `Active` earlier), so this streak measures uninterrupted
-        // silence. Beyond the cap, demote to `Idle` so a spoofed, zero-input
-        // "meeting" cannot bill a slot; any real input resets the streak.
+        // silence. Beyond the cap for the evidence at hand, demote to `Idle` so a
+        // spoofed, zero-input "meeting" cannot bill a slot; any real input resets
+        // the streak.
         if classification == crate::evaluator::ActivityClassification::Meeting {
             consecutive_silent_meeting += 1;
-            if consecutive_silent_meeting > MEETING_NO_INPUT_STREAK_CAP {
+            if consecutive_silent_meeting > meeting_streak_cap(meeting_confidence) {
                 classification = crate::evaluator::ActivityClassification::Idle;
                 demoted_meeting_minutes += 1;
             }
@@ -994,8 +1099,6 @@ pub fn aggregate_slot(db: &Database, config: &crate::config::AgentConfig, slot_s
         } else {
             slot_idle_segments += 1;
         }
-
-        was_recently_active = classification == crate::evaluator::ActivityClassification::Active;
 
         slot_keystrokes += log.keystroke_count;
         slot_clicks += log.mouse_click_count;
@@ -1727,15 +1830,16 @@ mod tests {
 
     #[test]
     fn test_aggregate_silent_meeting_is_capped() {
-        // A window whose title/app matches a meeting keyword but receives zero
-        // input for the whole slot must not bill (ADR 0002 addendum). Only
+        // A browser tab whose title merely contains a meeting keyword — the
+        // weak tier, which any rename produces — must not bill a slot on zero
+        // input for the whole slot (ADR 0002 addendum). Only
         // MEETING_NO_INPUT_STREAK_CAP minutes count; the rest demote to Idle.
         let db = Arc::new(create_test_db());
         let mut config = AgentConfig::default();
         config.engine_mode = "static".to_string();
 
         for i in 0..10 {
-            db.insert_minute_log(600 + i * 60, 0, 0, 0, 0.0, "zoom", "Zoom Meeting", false)
+            db.insert_minute_log(600 + i * 60, 0, 0, 0, 0.0, "Google Chrome", "zoom", false)
                 .unwrap();
         }
 
@@ -1863,6 +1967,150 @@ mod tests {
         )
     }
 
+    #[test]
+    fn test_aggregate_silent_strong_meeting_holds_a_slot() {
+        // Strong evidence — the native client is frontmost — is not reachable by
+        // renaming a window, so the spoof surface the weak cap absorbs is absent
+        // and a silent call holds the slot (#126).
+        let db = Arc::new(create_test_db());
+        let mut config = AgentConfig::default();
+        config.engine_mode = "static".to_string();
+
+        for i in 0..10 {
+            db.insert_minute_log(600 + i * 60, 0, 0, 0, 0.0, "zoom.us", "Zoom Meeting", false)
+                .unwrap();
+        }
+
+        aggregate_slot(&db, &config, 600);
+        let (active, idle, focus) = read_slot(&db, 600);
+        assert_eq!(active, 10, "a silent call on strong evidence is credited");
+        assert_eq!(idle, 0);
+        assert_eq!(focus, 100);
+    }
+
+    #[test]
+    fn test_aggregate_zoom_web_client_call_is_credited() {
+        // End to end over the sequence this issue was filed from: the join page
+        // identifies Zoom, then the web client retitles the tab to the meeting
+        // topic and no minute of the call identifies a meeting again.
+        let db = Arc::new(create_test_db());
+        let mut config = AgentConfig::default();
+        config.engine_mode = "static".to_string();
+
+        db.insert_minute_log(
+            600,
+            30,
+            14,
+            0,
+            0.0,
+            "Google Chrome",
+            "Join from Zoom Workplace app - Zoom",
+            false,
+        )
+        .unwrap();
+        for i in 1..10 {
+            db.insert_minute_log(
+                600 + i * 60,
+                0,
+                0,
+                0,
+                0.0,
+                "Google Chrome",
+                "Joe Yetter <> Pablo Fernandez \u{1f50a}",
+                false,
+            )
+            .unwrap();
+        }
+
+        aggregate_slot(&db, &config, 600);
+        let (active, idle, focus) = read_slot(&db, 600);
+        assert_eq!(active, 10, "the call is credited for its duration");
+        assert_eq!(idle, 0);
+        assert_eq!(focus, 100);
+    }
+
+    #[test]
+    fn test_meeting_is_carried_across_a_slot_boundary() {
+        // Calls do not begin on slot boundaries. The join page lands in the
+        // previous slot, so scoring this one from cold would lose the session
+        // and the whole call would read as idle (#126).
+        let db = Arc::new(create_test_db());
+        let mut config = AgentConfig::default();
+        config.engine_mode = "static".to_string();
+
+        db.insert_minute_log(
+            1140, // last minute of the previous slot
+            30,
+            14,
+            0,
+            0.0,
+            "Google Chrome",
+            "Join from Zoom Workplace app - Zoom",
+            false,
+        )
+        .unwrap();
+        for i in 0..10 {
+            db.insert_minute_log(
+                1200 + i * 60,
+                0,
+                0,
+                0,
+                0.0,
+                "Google Chrome",
+                "Joe Yetter <> Pablo Fernandez",
+                false,
+            )
+            .unwrap();
+        }
+
+        aggregate_slot(&db, &config, 1200);
+        let (active, idle, focus) = read_slot(&db, 1200);
+        assert_eq!(active, 10, "the call continues into this slot");
+        assert_eq!(idle, 0);
+        assert_eq!(focus, 100);
+    }
+
+    #[test]
+    fn test_a_gap_in_the_record_does_not_carry_a_meeting() {
+        // Same shape, but the machine was locked or asleep between the join page
+        // and the window we are scoring. Nothing is known about that interval, so
+        // the session must not survive it.
+        let db = Arc::new(create_test_db());
+        let mut config = AgentConfig::default();
+        config.engine_mode = "static".to_string();
+
+        db.insert_minute_log(
+            600,
+            30,
+            14,
+            0,
+            0.0,
+            "Google Chrome",
+            "Join from Zoom Workplace app - Zoom",
+            false,
+        )
+        .unwrap();
+        // ...then nothing until the next slot: a gap well past the tolerance.
+        for i in 0..10 {
+            db.insert_minute_log(
+                1200 + i * 60,
+                0,
+                0,
+                0,
+                0.0,
+                "Google Chrome",
+                "Joe Yetter <> Pablo Fernandez",
+                false,
+            )
+            .unwrap();
+        }
+
+        aggregate_slot(&db, &config, 1200);
+        let (active, idle, _) = read_slot(&db, 1200);
+        assert_eq!(active, 0, "no credit is carried across the gap");
+        assert_eq!(idle, 10);
+    }
+
     fn insert_silent_meeting(db: &Database, slot_start: i64, minutes: i64) {
         for i in 0..minutes {
             db.insert_minute_log(
@@ -1871,8 +2119,8 @@ mod tests {
                 0,
                 0,
                 0.0,
+                "Google Chrome",
                 "zoom",
-                "Zoom Meeting",
                 false,
             )
             .unwrap();
@@ -1917,13 +2165,22 @@ mod tests {
         config.engine_mode = "static".to_string();
 
         for i in 0..5 {
-            db.insert_minute_log(600 + i * 60, 0, 0, 0, 0.0, "zoom", "Zoom Meeting", false)
+            db.insert_minute_log(600 + i * 60, 0, 0, 0, 0.0, "Google Chrome", "zoom", false)
                 .unwrap();
         }
-        db.insert_minute_log(600 + 5 * 60, 100, 10, 0, 0.0, "zoom", "Zoom Meeting", false)
-            .unwrap();
+        db.insert_minute_log(
+            600 + 5 * 60,
+            100,
+            10,
+            0,
+            0.0,
+            "Google Chrome",
+            "zoom",
+            false,
+        )
+        .unwrap();
         for i in 6..10 {
-            db.insert_minute_log(600 + i * 60, 0, 0, 0, 0.0, "zoom", "Zoom Meeting", false)
+            db.insert_minute_log(600 + i * 60, 0, 0, 0, 0.0, "Google Chrome", "zoom", false)
                 .unwrap();
         }
 
@@ -1944,10 +2201,10 @@ mod tests {
         let mut config = AgentConfig::default();
         config.engine_mode = "static".to_string();
 
-        db.insert_minute_log(600, 100, 10, 0, 0.0, "zoom", "Zoom Meeting", false)
+        db.insert_minute_log(600, 100, 10, 0, 0.0, "Google Chrome", "zoom", false)
             .unwrap();
         for i in 1..10 {
-            db.insert_minute_log(600 + i * 60, 0, 0, 0, 0.0, "zoom", "Zoom Meeting", false)
+            db.insert_minute_log(600 + i * 60, 0, 0, 0, 0.0, "Google Chrome", "zoom", false)
                 .unwrap();
         }
 

--- a/daemon/src/db.rs
+++ b/daemon/src/db.rs
@@ -1794,6 +1794,11 @@ impl Database {
 
     /// Retrieve all raw minute logs within the specified slot window [slot_start, slot_start + 600).
     pub fn get_minute_logs_for_slot(&self, slot_start: i64) -> Result<Vec<MinuteLogData>> {
+        self.get_minute_logs_between(slot_start, slot_start + 600)
+    }
+
+    /// Retrieve all raw minute logs in `[from, to)`, oldest first.
+    pub fn get_minute_logs_between(&self, from: i64, to: i64) -> Result<Vec<MinuteLogData>> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
             "SELECT timestamp, keystroke_count, mouse_click_count, scroll_event_count, active_app_name, active_window_title, low_entropy, mouse_movement_distance 
@@ -1801,7 +1806,7 @@ impl Database {
              WHERE timestamp >= ?1 AND timestamp < ?2
              ORDER BY timestamp ASC"
         )?;
-        let rows = stmt.query_map(params![slot_start, slot_start + 600], |row| {
+        let rows = stmt.query_map(params![from, to], |row| {
             let low_entropy_int: i32 = row.get(6)?;
             Ok(MinuteLogData {
                 timestamp: row.get(0)?,
@@ -1866,9 +1871,21 @@ impl Database {
         let config = crate::config::load_config(config_path).unwrap_or_default();
         let evaluator = crate::evaluator::ActivityEvaluator::new();
 
+        // The drill-down explains a slot's score, so it has to be scored the way
+        // the slot was (#126): same rolling scanner, same silent-meeting
+        // demotion. Deriving either differently is what let this view call a
+        // minute `Inactive` that the slot total had counted `Productive`.
+        let mut scanner = crate::daemon::warmed_scanner(
+            self,
+            &config,
+            slot_start,
+            raw.first().map(|r| r.timestamp).unwrap_or(slot_start),
+        );
+        let mut consecutive_silent_meeting = 0u32;
+
         let mut list = Vec::new();
         for item in raw {
-            let classification =
+            let evaluated =
                 evaluator.evaluate_stored_minute(&crate::evaluator::StoredEvaluationContext {
                     keystroke_count: item.keystroke_count,
                     mouse_click_count: item.mouse_click_count,
@@ -1876,11 +1893,27 @@ impl Database {
                     active_app: &item.active_app_name,
                     active_title: &item.active_window_title,
                     low_entropy: item.low_entropy,
-                    was_recently_active: false,
+                    was_recently_active: scanner.was_recently_active(),
                     distracting_apps: &config.distracting_apps,
                     productive_apps: &config.productive_apps,
                     meeting_apps: &config.meeting_apps,
                 });
+            let (mut classification, meeting_confidence) = scanner.observe(
+                &item.active_app_name,
+                &item.active_window_title,
+                &config.meeting_apps,
+                evaluated,
+            );
+            if classification == crate::evaluator::ActivityClassification::Meeting {
+                consecutive_silent_meeting += 1;
+                if consecutive_silent_meeting
+                    > crate::daemon::meeting_streak_cap(meeting_confidence)
+                {
+                    classification = crate::evaluator::ActivityClassification::Idle;
+                }
+            } else {
+                consecutive_silent_meeting = 0;
+            }
             let state = match classification {
                 crate::evaluator::ActivityClassification::Active
                 | crate::evaluator::ActivityClassification::PassiveReview => "Productive",

--- a/daemon/src/evaluator.rs
+++ b/daemon/src/evaluator.rs
@@ -80,30 +80,134 @@ fn title_has_meeting_url(title: &str) -> bool {
         })
 }
 
-/// Whether the active window represents a genuine meeting (issue #97). Native
-/// meeting clients are matched by application name (hard to spoof); browser-hosted
-/// meetings are matched by a whole-word title keyword or a Meet URL/code, so a
-/// document merely titled "Meeting notes" or a window renamed to contain "zoom"
-/// is not mistaken for one. This hardens the spoof surface the ADR-0002 no-input
-/// cap must absorb; it does NOT prove a human is present in a live call (see #94).
-/// `app_lower` / `title_lower` are lowercase.
-fn is_meeting_context(app_lower: &str, title_lower: &str, meeting_apps: &str) -> bool {
-    for keyword in meeting_apps
-        .split(',')
-        .map(|s| s.trim().to_lowercase())
-        .filter(|s| !s.is_empty())
-    {
-        // Native client: the running application itself matches (trusted name).
-        if app_lower.contains(&keyword) {
-            return true;
-        }
-        // Browser tab / window title: whole-word keyword match.
-        if title_matches_keyword(title_lower, &keyword) {
-            return true;
-        }
+/// How strongly the active window identifies a live meeting. The distinction
+/// exists because the ADR-0002 no-input streak cap has to absorb every false
+/// meeting classification: evidence that survives a window rename earns a longer
+/// silent streak than evidence that does not.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MeetingConfidence {
+    /// A native meeting client is frontmost, the title carries a platform's own
+    /// structural shell, or a join transition was observed. None of these come
+    /// from renaming a window.
+    Strong,
+    /// A `meeting_apps` keyword appears as a whole word in the title and nothing
+    /// else corroborates it. User-extensible, and spoofable by renaming.
+    Weak,
+}
+
+/// En/em dashes rewritten to ASCII so a platform's title shell matches whichever
+/// dash it ships (Google Meet uses both `Meet - x` and `Meet – x`).
+fn canonical_dashes(title: &str) -> String {
+    title.replace(['\u{2013}', '\u{2014}'], "-")
+}
+
+/// Platform-authored title shells: the wrapper a meeting product puts around the
+/// meeting's own name. Structural rather than keyword-based, so a document called
+/// "Meet Sol, the new model" is not a meeting while `Meet - Standup` is.
+/// `title_lower` is lowercase.
+fn title_has_meeting_shell(title_lower: &str) -> bool {
+    let t = canonical_dashes(title_lower);
+    let t = t.trim();
+    // Google Meet: "Meet - <topic>" / "Meet – <topic>".
+    if t.starts_with("meet - ") {
+        return true;
     }
-    // Browser-hosted meeting recognizable only by its URL/code.
-    title_has_meeting_url(title_lower)
+    // Microsoft Teams, native and web: "<topic> | Microsoft Teams".
+    if t.ends_with("| microsoft teams") || t.contains("| microsoft teams |") {
+        return true;
+    }
+    // Zoom, including the launcher page and the native window.
+    if t.ends_with("- zoom") || t.contains("zoom workplace") || t.contains("zoom meeting") {
+        return true;
+    }
+    // Webex.
+    if t.starts_with("webex |") || t.contains("cisco webex") || t.contains("webex meetings") {
+        return true;
+    }
+    // Slack huddles.
+    if t.contains("| huddle") || t.contains("huddle |") {
+        return true;
+    }
+    false
+}
+
+/// A page that launches or joins a call, as opposed to the call itself. Seeing
+/// one is what licenses [`MeetingSession`] to adopt the next title in the same
+/// application: Zoom's web client titles its join page `Join from Zoom Workplace
+/// app - Zoom` and then retitles the tab to the meeting topic alone, which
+/// carries no platform marker of its own. `title_lower` is lowercase.
+fn is_meeting_launcher(title_lower: &str) -> bool {
+    const LAUNCHERS: [&str; 6] = [
+        "join from zoom",
+        "zoom workplace app",
+        "meeting join",
+        "join meeting",
+        "launching meeting",
+        "start your meeting",
+    ];
+    LAUNCHERS.iter().any(|p| title_lower.contains(p))
+}
+
+/// Compare titles across minutes without tripping over decoration the browser
+/// adds and removes on its own: Chrome appends a speaker glyph while a tab plays
+/// audio and prefixes an unread count. Lowercased, stripped of a leading `(n) `,
+/// non-ASCII removed and whitespace collapsed — applied to both sides, so it only
+/// has to be consistent, not pretty.
+fn normalize_title(title_lower: &str) -> String {
+    let mut t = title_lower.trim();
+    if let Some(rest) = t.strip_prefix('(')
+        && let Some((count, after)) = rest.split_once(')')
+        && !count.is_empty()
+        && count.chars().all(|c| c.is_ascii_digit())
+    {
+        t = after.trim_start();
+    }
+    t.chars()
+        .filter(|c| c.is_ascii())
+        .collect::<String>()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Whether the active window represents a genuine meeting, and how strongly
+/// (issue #126, narrowing the #97 hardening). Native meeting clients are matched
+/// by application name and platform title shells by structure, so a document
+/// merely titled "Meeting notes" or a window renamed to contain "zoom" is not
+/// mistaken for one. A bare title keyword still matches, at `Weak`. None of this
+/// proves a human is present in a live call. `app_lower` / `title_lower` are
+/// lowercase.
+fn meeting_context(
+    app_lower: &str,
+    title_lower: &str,
+    meeting_apps: &str,
+) -> Option<MeetingConfidence> {
+    let keywords = || {
+        meeting_apps
+            .split(',')
+            .map(|s| s.trim().to_lowercase())
+            .filter(|s| !s.is_empty())
+    };
+
+    // Native client: the running application itself matches (trusted name).
+    if keywords().any(|k| app_lower.contains(&k)) {
+        return Some(MeetingConfidence::Strong);
+    }
+    // Browser-hosted meeting identified by the platform's own title shell, or by
+    // a Meet URL/code.
+    if title_has_meeting_shell(title_lower) || title_has_meeting_url(title_lower) {
+        return Some(MeetingConfidence::Strong);
+    }
+    // Browser tab / window title: whole-word keyword match, spoofable by rename.
+    if keywords().any(|k| title_matches_keyword(title_lower, &k)) {
+        return Some(MeetingConfidence::Weak);
+    }
+    None
+}
+
+/// Whether the active window represents a genuine meeting at all.
+fn is_meeting_context(app_lower: &str, title_lower: &str, meeting_apps: &str) -> bool {
+    meeting_context(app_lower, title_lower, meeting_apps).is_some()
 }
 
 impl ActivityEvaluator {
@@ -216,6 +320,154 @@ impl ActivityEvaluator {
         }
 
         ActivityClassification::Idle
+    }
+}
+
+/// How long a minute keeps granting passive-review credit after the last minute
+/// of real input.
+///
+/// Deliberately 1. Crediting a thinking pause is contextual idle forgiveness
+/// (ADR 0011), which grants it only when the pause is short *and* work genuinely
+/// resumes afterwards. Widening this window would hand out the same credit with
+/// neither condition attached, so a whitelisted app left open would earn for as
+/// long as the window ran — a strictly weaker rule reached by a second route.
+/// The constant exists so the horizon is stated once and every call site derives
+/// it identically, which is what [`MinuteScanner`] is for.
+pub const RECENT_ACTIVITY_WINDOW_MINUTES: u32 = 1;
+
+/// A meeting session is dropped after this long without any corroboration, so a
+/// tab left open on a finished call cannot keep earning indefinitely.
+const MEETING_SESSION_MAX_MINUTES: u32 = 240;
+
+/// A meeting being tracked across minutes.
+struct MeetingSession {
+    /// Lowercased application the meeting lives in.
+    app: String,
+    /// Normalized title being held (see [`normalize_title`]).
+    title: String,
+    confidence: MeetingConfidence,
+    /// Whether a title change should be read as the call starting rather than as
+    /// the meeting ending. Set only while the window is a launcher page, and the
+    /// launcher re-anchors the session every minute it stays frontmost, so the
+    /// change has to follow it immediately.
+    adopt_next_title: bool,
+    /// Minutes this session has been held without fresh direct evidence.
+    held: u32,
+}
+
+/// Per-minute classifier state shared by every call site that scores minutes.
+///
+/// It carries the two things a single minute cannot know on its own: how
+/// recently the user last supplied input, and whether an ongoing meeting explains
+/// a window that no longer looks like one. Sharing one implementation is what
+/// keeps a slot's total and its per-minute drill-down from disagreeing about the
+/// same minute.
+///
+/// Callers read [`Self::was_recently_active`] before classifying a minute, then
+/// hand the verdict back to [`Self::observe`], which may upgrade it and advances
+/// the rolling state.
+#[derive(Default)]
+pub struct MinuteScanner {
+    recent_active: u32,
+    session: Option<MeetingSession>,
+}
+
+impl MinuteScanner {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Whether input landed inside the recent-activity window. Feed this into
+    /// [`LiveEvaluationContext::was_recently_active`] or its stored counterpart.
+    pub fn was_recently_active(&self) -> bool {
+        self.recent_active > 0
+    }
+
+    /// Advance the rolling state with this minute's window and verdict, and
+    /// return the verdict the caller should record.
+    ///
+    /// A minute already credited is never downgraded here: only `Idle` is
+    /// upgraded, and only when a meeting session covers it. The returned
+    /// confidence is `Some` exactly when the verdict is `Meeting`, and selects
+    /// which no-input streak cap applies to it.
+    pub fn observe(
+        &mut self,
+        active_app: &str,
+        active_title: &str,
+        meeting_apps: &str,
+        classification: ActivityClassification,
+    ) -> (ActivityClassification, Option<MeetingConfidence>) {
+        let app_lower = active_app.to_lowercase();
+        let title_lower = active_title.to_lowercase();
+        let direct = meeting_context(&app_lower, &title_lower, meeting_apps);
+        let covering = self.advance_session(&app_lower, &title_lower, direct);
+
+        let mut verdict = classification;
+        if verdict == ActivityClassification::Idle && covering.is_some() {
+            verdict = ActivityClassification::Meeting;
+        }
+
+        if verdict == ActivityClassification::Active {
+            self.recent_active = RECENT_ACTIVITY_WINDOW_MINUTES;
+        } else {
+            self.recent_active = self.recent_active.saturating_sub(1);
+        }
+
+        let confidence = if verdict == ActivityClassification::Meeting {
+            // A directly matched meeting reports its own strength even when no
+            // session is being carried (the first minute of one).
+            covering.or(direct)
+        } else {
+            None
+        };
+        (verdict, confidence)
+    }
+
+    /// Open, continue, adopt or drop the tracked meeting for this minute, and
+    /// return the confidence covering it.
+    fn advance_session(
+        &mut self,
+        app_lower: &str,
+        title_lower: &str,
+        direct: Option<MeetingConfidence>,
+    ) -> Option<MeetingConfidence> {
+        let title_norm = normalize_title(title_lower);
+
+        if let Some(confidence) = direct {
+            // Anchor on what we can see now. Only a launcher page licenses a
+            // later title change to be read as the call starting.
+            self.session = Some(MeetingSession {
+                app: app_lower.to_string(),
+                title: title_norm,
+                confidence,
+                adopt_next_title: is_meeting_launcher(title_lower),
+                held: 0,
+            });
+            return Some(confidence);
+        }
+
+        if let Some(session) = self.session.as_mut()
+            && session.app == app_lower
+        {
+            if session.title == title_norm {
+                session.held += 1;
+                if session.held <= MEETING_SESSION_MAX_MINUTES {
+                    return Some(session.confidence);
+                }
+            } else if session.adopt_next_title {
+                // The join page became the call. The meeting's own title carries
+                // no platform marker, so this is the only point at which it can
+                // be learned.
+                session.title = title_norm;
+                session.confidence = MeetingConfidence::Strong;
+                session.adopt_next_title = false;
+                session.held = 0;
+                return Some(MeetingConfidence::Strong);
+            }
+        }
+
+        self.session = None;
+        None
     }
 }
 
@@ -454,6 +706,227 @@ mod tests {
         assert_eq!(
             e.evaluate_minute(&no_input_ctx("Finder", "myzoomrecording.mp4", "zoom, meet")),
             ActivityClassification::Idle
+        );
+    }
+
+    // --- browser-hosted meeting continuity (#126) ---
+    //
+    // The titles below are real ones observed on a developer machine, including
+    // the Zoom web-client sequence that motivated this issue.
+
+    const MEETINGS: &str = "zoom, meet, teams, webex, slack | huddle";
+
+    /// Drive the scanner over consecutive minutes of `(app, title, keystrokes)`.
+    /// `productive_apps` deliberately excludes browsers so passive-review credit
+    /// cannot mask what the meeting logic is doing.
+    fn drive(
+        minutes: &[(&str, &str, u32)],
+    ) -> Vec<(ActivityClassification, Option<MeetingConfidence>)> {
+        let evaluator = ActivityEvaluator::new();
+        let mut scanner = MinuteScanner::new();
+        minutes
+            .iter()
+            .map(|(app, title, keys)| {
+                let ctx = StoredEvaluationContext {
+                    keystroke_count: *keys,
+                    mouse_click_count: 0,
+                    scroll_event_count: 0,
+                    active_app: app,
+                    active_title: title,
+                    low_entropy: false,
+                    was_recently_active: scanner.was_recently_active(),
+                    distracting_apps: "youtube, netflix",
+                    productive_apps: "vscode, cursor",
+                    meeting_apps: MEETINGS,
+                };
+                let evaluated = evaluator.evaluate_stored_minute(&ctx);
+                scanner.observe(app, title, MEETINGS, evaluated)
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_platform_title_shells_are_strong() {
+        for title in [
+            "meet - david/pablo sync",
+            "meet \u{2013} pablo / jorge",
+            "meet \u{2013} pablo / jorge - fen\u{ea}tre de la pr\u{e9}sentation",
+            "call re. vp eng role: pablo & paul | microsoft teams",
+            "meeting join | microsoft teams meeting | microsoft teams",
+            "join from zoom workplace app - zoom",
+            "cisco webex meetings",
+            "acme \u{2014} slack | huddle",
+        ] {
+            assert!(
+                title_has_meeting_shell(title),
+                "shell should match: {title}"
+            );
+            assert_eq!(
+                meeting_context("google chrome", title, MEETINGS),
+                Some(MeetingConfidence::Strong),
+                "should be strong: {title}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_native_client_is_strong_and_bare_keyword_is_weak() {
+        assert_eq!(
+            meeting_context("zoom.us", "zoom", MEETINGS),
+            Some(MeetingConfidence::Strong)
+        );
+        // A whole-word keyword and nothing else: any rename produces this, so it
+        // keeps the lower tier and the tighter streak cap.
+        assert_eq!(
+            meeting_context(
+                "google chrome",
+                "gpt-5.6: meet sol, terra and luna",
+                MEETINGS
+            ),
+            Some(MeetingConfidence::Weak)
+        );
+    }
+
+    #[test]
+    fn test_non_meeting_pages_still_match_nothing() {
+        for title in [
+            "recall.ai: the universal api for meeting bots | product hunt",
+            "meeting notes - q3",
+            "myzoomrecording.mp4",
+            "meeting with michael - gmail",
+        ] {
+            assert_eq!(
+                meeting_context("google chrome", title, MEETINGS),
+                None,
+                "should not match: {title}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_normalize_title_ignores_browser_decoration() {
+        // Chrome appends a speaker glyph while a tab plays audio and prefixes an
+        // unread count; neither means the meeting ended.
+        assert_eq!(
+            normalize_title("joe yetter <> pablo fernandez \u{1f50a}"),
+            normalize_title("joe yetter <> pablo fernandez")
+        );
+        assert_eq!(
+            normalize_title("(3) joe yetter <> pablo fernandez"),
+            normalize_title("joe yetter <> pablo fernandez")
+        );
+    }
+
+    #[test]
+    fn test_zoom_web_client_call_stays_a_meeting() {
+        // The observed sequence: the join page carries a Zoom marker, then the
+        // web client retitles the tab to the meeting topic alone and nothing in
+        // the window identifies a meeting again until the call ends.
+        let out = drive(&[
+            ("Google Chrome", "Join from Zoom Workplace app - Zoom", 30),
+            ("Google Chrome", "Joe Yetter <> Pablo Fernandez", 4),
+            ("Google Chrome", "Joe Yetter <> Pablo Fernandez", 0),
+            (
+                "Google Chrome",
+                "Joe Yetter <> Pablo Fernandez \u{1f50a}",
+                0,
+            ),
+            (
+                "Google Chrome",
+                "Joe Yetter <> Pablo Fernandez \u{1f50a}",
+                0,
+            ),
+            ("Google Chrome", "Carol: Day grid reservation", 11),
+            ("Google Chrome", "Carol: Day grid reservation", 0),
+        ]);
+
+        assert_eq!(out[0].0, ActivityClassification::Active);
+        assert_eq!(out[1].0, ActivityClassification::Active);
+        for i in 2..=4 {
+            assert_eq!(
+                out[i],
+                (
+                    ActivityClassification::Meeting,
+                    Some(MeetingConfidence::Strong)
+                ),
+                "minute {i} of the call"
+            );
+        }
+        // The call ends when the window becomes unrelated content.
+        assert_eq!(out[5].0, ActivityClassification::Active);
+        assert_eq!(out[6].0, ActivityClassification::Idle);
+    }
+
+    #[test]
+    fn test_only_a_launcher_licenses_adopting_a_new_title() {
+        // "Meet - Standup" identifies itself for the whole call, so it never
+        // needs adoption — and must not hand its credit to the next tab.
+        let out = drive(&[
+            ("Google Chrome", "Meet - Standup", 0),
+            ("Google Chrome", "reddit: the front page", 0),
+        ]);
+        assert_eq!(
+            out[0],
+            (
+                ActivityClassification::Meeting,
+                Some(MeetingConfidence::Strong)
+            )
+        );
+        assert_eq!(out[1].0, ActivityClassification::Idle);
+    }
+
+    #[test]
+    fn test_meeting_session_does_not_follow_an_app_switch() {
+        let out = drive(&[
+            ("Google Chrome", "Join from Zoom Workplace app - Zoom", 5),
+            ("Google Chrome", "Joe <> Pablo", 0),
+            ("Finder", "Joe <> Pablo", 0),
+        ]);
+        assert_eq!(out[1].0, ActivityClassification::Meeting);
+        assert_eq!(out[2].0, ActivityClassification::Idle);
+    }
+
+    #[test]
+    fn test_recent_activity_window_covers_a_reading_pause() {
+        // One minute of input, then silence in a whitelisted app. Credit lasts
+        // the rolling window rather than a single minute.
+        let mut minutes = vec![("VSCode", "main.rs", 40u32)];
+        minutes.extend(std::iter::repeat(("VSCode", "main.rs", 0u32)).take(12));
+        let out = drive(&minutes);
+
+        assert_eq!(out[0].0, ActivityClassification::Active);
+        for i in 1..=RECENT_ACTIVITY_WINDOW_MINUTES as usize {
+            assert_eq!(
+                out[i].0,
+                ActivityClassification::PassiveReview,
+                "minute {i} should still be within the window"
+            );
+        }
+        assert_eq!(
+            out[RECENT_ACTIVITY_WINDOW_MINUTES as usize + 1].0,
+            ActivityClassification::Idle,
+            "credit ends once the window closes"
+        );
+    }
+
+    #[test]
+    fn test_input_during_a_call_reopens_the_window() {
+        // A call the user types in stays Active, and the meeting session survives
+        // the interruption because the window never changed.
+        let out = drive(&[
+            ("Google Chrome", "Join from Zoom Workplace app - Zoom", 5),
+            ("Google Chrome", "Joe <> Pablo", 0),
+            ("Google Chrome", "Joe <> Pablo", 22),
+            ("Google Chrome", "Joe <> Pablo", 0),
+        ]);
+        assert_eq!(out[1].0, ActivityClassification::Meeting);
+        assert_eq!(out[2].0, ActivityClassification::Active);
+        assert_eq!(
+            out[3],
+            (
+                ActivityClassification::Meeting,
+                Some(MeetingConfidence::Strong)
+            )
         );
     }
 }


### PR DESCRIPTION
## TL;DR

`closes #126`

A silent browser-hosted Zoom call scored as idle. Zoom's web client retitles its tab to the
meeting topic once the call starts, so after the first minute nothing in the app name or window
title says "meeting". Google Meet and Teams were never affected — they keep their marker every
minute.

Two judgement calls to overrule if you disagree:

1. **Meeting matching now has two tiers, and the no-input streak cap is per tier.** A window
   renamed to contain `zoom` keeps the existing cap of 3. A native client, a platform title shell,
   or an observed join transition may hold a full slot. The anti-spoof property is unchanged for
   the tier the spoof actually applies to.
2. **I did not widen `was_recently_active`,** which is the other half of what this started as. It
   duplicates contextual idle forgiveness (ADR 0011) with weaker conditions — no resumption check —
   so any window >1 minute would grant credit for walking away from a whitelisted app. The constant
   `RECENT_ACTIVITY_WINDOW_MINUTES` exists and is set to 1, so it is a one-line change if you want
   it. The consistency half of that fix *is* here.

## Context

Detection reads the frontmost application name and window title. Real titles from a developer
machine:

| what | title | matched before? |
|---|---|---|
| Google Meet | `Meet – Pablo / Jorge 🔊` | yes |
| Teams (native) | `… \| Microsoft Teams` | yes |
| Zoom web, join page | `Join from Zoom Workplace app - Zoom` | yes |
| Zoom web, **in call** | `Joe Yetter <> Pablo Fernandez` | **no** |

The call minutes match nothing, so they fell through to `Idle`. The #97 hardening is what makes
this visible rather than accidental: matching is precise enough now that a window carrying no
marker genuinely matches nothing.

The streak cap compounded it. A single cap of 3 was set against the weakest evidence the detector
accepts — a title keyword, which any rename produces — then applied to every meeting including
ones identified by the running binary.

## Changes

- **`MeetingConfidence`** — `Strong` (native client by app name, platform title shell for Meet /
  Teams / Zoom / Webex / Slack huddles, or a Meet URL/code) vs `Weak` (a whole-word `meeting_apps`
  keyword alone). Shells are structural, so `Meet - Standup` matches and `Meet Sol, the new model`
  does not.
- **`MEETING_NO_INPUT_STREAK_CAP_STRONG`** (10, a full ADR-0007 slot) alongside the existing cap of
  3 for weak evidence. Every guarantee the old cap gave is preserved by the weak-tier tests, which
  are the original tests re-pointed at a genuinely weak window.
- **`MinuteScanner`** — carries the recent-input window and an in-progress meeting across minutes.
  A launcher page licenses the next distinct title in the same app to be adopted as the call's own.
  Ends on an unrelated window, an app switch, `MEETING_SESSION_MAX_MINUTES`, or a gap in the record.
  Titles compare normalized, so the speaker glyph a browser appends while a tab plays audio does not
  end a call.
- **`warmed_scanner`** — calls do not begin on slot boundaries, so both scoring paths replay a
  bounded window of preceding minutes before scoring. Without this the session died every ten
  minutes. A gap in the replayed history resets the state: telemetry stops while the machine is
  locked or asleep, and what was frontmost before such a gap is not evidence about what is frontmost
  after it.
- **One source for the rolling state.** It was recomputed at four call sites, and
  `get_slot_minute_details` passed `was_recently_active: false` unconditionally, so the drill-down
  could report a minute `Inactive` that the slot total had counted `Productive`. It now applies the
  same silent-meeting demotion the slot did.
- `AUDIT.md` §"How a minute is classified" rewritten for the tiers, the session, and the recent-
  activity horizon. Six line-anchored code citations that this change invalidated are now cited by
  symbol name instead.

## Verification

`cargo fmt`, `cargo clippy -- -D warnings`, `cargo test` green in `daemon` (156) and
`desktop/src-tauri` (15).

Beyond unit tests, the aggregation path was replayed over real recorded minutes for a 41-minute
browser-hosted call (34 of them with zero input):

| slot | before | after |
|---|---|---|
| +00 | 90% | 90% |
| +10 | 70% | 100% |
| +20 | 20% | 100% |
| +30 | **0%** | 100% |
| +40 | 20% | 100% |

Worth knowing: the cross-slot flaw only showed up in that replay. Every unit test passed while a
call spanning a slot boundary still scored zero, because the tests put the join page and the call
in the same slot. `test_meeting_is_carried_across_a_slot_boundary` and
`test_a_gap_in_the_record_does_not_carry_a_meeting` pin it now.

## Not in this PR

- **Presence is still not proven.** This establishes that a meeting window was frontmost, which is
  the limit of what app name and window title can show. The corroborating-signal follow-up
  (mic/camera in use) is still the way to close that, and is still unbuilt. ADR 0002's "known
  limitation" is narrowed, not removed.
- **A voice call in a blacklisted app still reads as waste.** A window titled
  `Miriam - WhatsApp voice call` classifies `Distracted`, because the distraction check runs before
  any call detection and has no call exemption. Separate decision, separate issue.
- **The drill-down loads config from disk** while `aggregate_slot` scores with the config passed in,
  so re-opening an old slot after a config change re-scores it under the new lists. Pre-existing,
  and `slot_summaries.config_hash` suggests it was already known.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
